### PR TITLE
Skip testing on mono

### DIFF
--- a/test/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
+++ b/test/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace />
 


### PR DESCRIPTION
Tests on mono were failing far too frequently for the pipeline stability we want.
