### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,13 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.6",
+      "version": "7.4.0",
       "commands": [
         "pwsh"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "dotnet-coverage": {
-      "version": "17.8.2",
+      "version": "17.9.3",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:7.0.302-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.100-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,3 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  ignore:
-    # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-    - dependency-name: dotnet-format
-      versions: ["6.x", "7.x", "8.x"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,9 @@
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,
   "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
+  "editor.formatOnSave": true,
+  "[xml]": {
+    "editor.wordWrap": "off"
+  },
   "dotnet.defaultSolution": "Nerdbank.Streams.sln"
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -5,7 +6,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- https://learn.microsoft.com/nuget/consume-packages/central-package-management -->
   <PropertyGroup>
@@ -14,7 +15,7 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.6.11" />
@@ -27,11 +28,11 @@
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
     <PackageVersion Include="xunit.combinatorial" Version="1.6.24" />
-    <PackageVersion Include="xunit.extensibility.core" Version="2.5.0" />
+    <PackageVersion Include="xunit.extensibility.core" Version="2.6.2" />
     <PackageVersion Include="xunit.runner.console" Version="2.5.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.4" />
     <PackageVersion Include="xunit.skippablefact" Version="1.4.13" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit" Version="2.6.2" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
@@ -41,6 +42,6 @@
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/artifacts/_stage_all.ps1
+++ b/azure-pipelines/artifacts/_stage_all.ps1
@@ -30,6 +30,12 @@ function Create-SymbolicLink {
     } else {
         cmd /c "mklink `"$Link`" `"$Target`"" | Out-Null
     }
+
+    if ($LASTEXITCODE -ne 0) {
+        # Windows requires admin privileges to create symbolic links
+        # unless Developer Mode has been enabled.
+        throw "Failed to create symbolic link at $Link that points to $Target"
+    }
 }
 
 # Stage all artifacts

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -44,6 +44,8 @@ jobs:
   - template: dotnet.yml
     parameters:
       RunTests: ${{ parameters.RunTests }}
+  - script: dotnet format --verify-no-changes --no-restore
+    displayName: 💅 Verify formatted code
   - template: node.yml
   - template: collect-artifacts.yml
     parameters:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "8.0.100",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/settings.VisualStudio.json
+++ b/settings.VisualStudio.json
@@ -1,0 +1,3 @@
+{
+  "textEditor.codeCleanup.profile": "profile1"
+}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <!-- Include and reference README in nuget package, if a README is in the project directory. -->
   <PropertyGroup>
     <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/test/Nerdbank.Streams.Tests/MultiplexingStreamPerfTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStreamPerfTests.cs
@@ -141,7 +141,7 @@ public class MultiplexingStreamPerfTests : TestBase, IAsyncLifetime
                                 MultiplexingStream.Channel? channel = await mxServer.OfferChannelAsync(string.Empty, this.TimeoutToken).WithCancellation(this.TimeoutToken);
                                 for (int i = 0; i < segmentCount / ChannelCount; i++)
                                 {
-                                     await channel.Output.WriteAsync(serverBuffer, this.TimeoutToken);
+                                    await channel.Output.WriteAsync(serverBuffer, this.TimeoutToken);
                                 }
                             })));
                     }),

--- a/test/Nerdbank.Streams.Tests/NestedStreamTests.cs
+++ b/test/Nerdbank.Streams.Tests/NestedStreamTests.cs
@@ -38,7 +38,7 @@ public class NestedStreamTests : TestBase
 
         // Assert that read functions were not called.
         Assert.Same(typeof(Stream).GetProperty(nameof(Stream.CanRead))!.GetMethod, Assert.Single(noReadStream.ReceivedCalls()).GetMethodInfo());
-   }
+    }
 
     [Fact]
     public void CanSeek()

--- a/test/Nerdbank.Streams.Tests/StreamPipeReaderTestBase.cs
+++ b/test/Nerdbank.Streams.Tests/StreamPipeReaderTestBase.cs
@@ -95,10 +95,12 @@ public abstract class StreamPipeReaderTestBase : TestBase
         // and shouldn't give us any more buffer.
         ValueTask<ReadResult> resultTask = reader.ReadAsync(this.TimeoutToken);
         Assert.True(resultTask.IsCompleted);
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
         Assert.Equal(result.Buffer.Length, resultTask.Result.Buffer.Length);
 
         // Now examine everything, but don't consume it. We should get more.
         reader.AdvanceTo(resultTask.Result.Buffer.Start, resultTask.Result.Buffer.End);
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
         ValueTask<ReadResult> resultTask2 = reader.ReadAsync(this.TimeoutToken);
         Assert.False(resultTask2.IsCompleted);
         stream.Write(expectedBuffer, 50, 50);


### PR DESCRIPTION
- Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 (#213)
- Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#214)
- Bump dotnet-coverage from 17.8.2 to 17.8.4 (#215)
- Align YAML indentation more consistently
- Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 (#218)
- Fix typo in comment
- Bump dotnet-coverage to 17.8.6
- Bump xunit from 2.5.0 to 2.5.1 (#219)
- Bump xunit.runner.visualstudio from 2.5.0 to 2.5.1 (#220)
- Bump powershell to 7.3.7
- Fix LangVersion at 11
- Bump dotnet-coverage to 17.8.7
- Revert "Bump dotnet-coverage to 17.8.7"
- Bump .NET SDK to 7.0.401
- Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3 (#224)
- Bump dotnet-coverage from 17.8.6 to 17.9.1 (#222)
- Bump powershell from 7.3.7 to 7.3.8 (#221)
- Bump xunit from 2.5.1 to 2.5.2 (#223)
- Bump xunit from 2.5.2 to 2.5.3 (#226)
- Bump dotnet-coverage from 17.9.1 to 17.9.3 (#225)
- Bump powershell from 7.3.8 to 7.3.9 (#227)
- Bump xunit from 2.5.3 to 2.6.1 (#228)
- Ignore `dotnet-format` v9 versions
- Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 (#229)
- Apply Directory.Packages.props in Apply-Template.ps1
- Bump to the .NET 8.0.100 SDK
- Bump xunit from 2.6.1 to 2.6.2 (#234)
- Bump Microsoft.SourceLink.GitHub from 1.1.1 to 8.0.0 (#232)
- Bump powershell from 7.3.9 to 7.4.0 (#231)
- Bump xunit.runner.visualstudio from 2.5.3 to 2.5.4 (#233)
- Validate formatted code in builds
- Enable auto-format on save in VS and VS Code
- Remove `dotnet-format` as a tool
- Make symbolic link failures more detectable
- Add xml header to msbuild files
- Stop VS Code from wrapping xml files
- Address build warnings
