### PR TITLE
Avoid loading strings unless needed

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.Options.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Options.cs
@@ -257,7 +257,14 @@ namespace Nerdbank.Streams
             /// <returns>This instance if already frozen, otherwise a frozen copy.</returns>
             public Options GetFrozenCopy() => this.IsFrozen ? this : new Options(this, frozen: true);
 
-            private void ThrowIfFrozen() => Verify.Operation(!this.IsFrozen, Strings.Frozen);
+            private void ThrowIfFrozen()
+            {
+                // Avoid loading string unless needed
+                if (this.IsFrozen)
+                {
+                    Verify.FailOperation(Strings.Frozen);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This was between 5ms -> 15ms during VS startup on the UI thread.

![image](https://github.com/user-attachments/assets/23a379b2-824e-42e5-816a-2916c324b472)
