### PR TITLE
Fix node.js stream blockage in mxstream channels

### DIFF
--- a/src/nerdbank-streams/src/Channel.ts
+++ b/src/nerdbank-streams/src/Channel.ts
@@ -220,7 +220,7 @@ export class ChannelClass extends Channel {
 
 		// We should find a way to detect when we *actually* share the received buffer with the Channel's user
 		// and only report consumption when they receive the buffer from us so that we effectively apply
-		// backpressure to the remote party based on our user's actual consumption rather than keep allocating memory.
+		// backpressure to the remote party based on our user's actual consumption rather than continually allocating memory.
 		if (this._multiplexingStream.backpressureSupportEnabled && buffer) {
 			this._multiplexingStream.localContentExamined(this, buffer.length)
 		}

--- a/src/nerdbank-streams/src/Utilities.ts
+++ b/src/nerdbank-streams/src/Utilities.ts
@@ -92,12 +92,12 @@ export async function getBufferFrom(
 					throw new Error('Stream terminated before required bytes were read.')
 				}
 
-				// Returns what has been read so far
+				// Returns what has been read so far.
 				if (readBuffer === null) {
 					return null
 				}
 
-				// we need trim extra spaces
+				// We need to trim the trailing space.
 				return readBuffer.subarray(0, index)
 			}
 
@@ -116,11 +116,11 @@ export async function getBufferFrom(
 
 			if (readBuffer === null) {
 				if (availableSize === size || newBuffer.length < availableSize) {
-					// in the fast pass, we read the entire data once, and donot allocate an extra array.
+					// In the fast pass, we read the entire data once, and do not allocate an extra array.
 					return newBuffer
 				}
 
-				// if we read partial data, we need allocate a buffer to join all data together.
+				// If we read partial data, we need to allocate a buffer to join all data together.
 				readBuffer = Buffer.alloc(size)
 			}
 


### PR DESCRIPTION
When the node.js implementation of a `MultiplexingStream` channel receives more data than the highWatermark (16KB) limit, a flowing stream stops flowing permanently, blocking all communication in that direction.
    
This fixes the problem by calling `resume()` on the stream when flowing has been stopped by that particular data buffer.