### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.0",
+      "version": "2.78.1",
       "commands": [
         "docfx"
       ],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     interval: weekly
   ignore:
   - dependency-name: Microsoft.Bcl.AsyncInterfaces # We want to match the minimum target .NET runtime
+- package-ecosystem: dotnet-sdk
+  directory: /
+  schedule:
+    interval: monthly

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,14 +15,13 @@
     <PackageVersion Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="PInvoke.Kernel32" Version="0.7.124" />
-    <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.17" />
     <PackageVersion Include="System.IO.Pipelines" Version="8.0.0" />
     <PackageVersion Include="System.IO.Pipes" Version="4.3.0" />
@@ -41,7 +40,7 @@
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
-    <GlobalPackageReference Include="Nullable" Version="1.3.1" />
+    <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/Get-CodeCovTool.ps1
+++ b/azure-pipelines/Get-CodeCovTool.ps1
@@ -68,7 +68,7 @@ if (!(Test-Path $finalToolPath)) {
     }
 
     Write-Host "Verifying hash on downloaded tool" -ForegroundColor Yellow
-    $actualHash = (Get-FileHash -Path $tool -Algorithm SHA256).Hash
+    $actualHash = (Get-FileHash -LiteralPath $tool -Algorithm SHA256).Hash
     $expectedHash = (Get-Content $sha).Split()[0]
     if ($actualHash -ne $expectedHash) {
         # Validation failed. Delete the tool so we can't execute it.

--- a/azure-pipelines/Merge-CodeCoverage.ps1
+++ b/azure-pipelines/Merge-CodeCoverage.ps1
@@ -28,7 +28,7 @@ try {
     if ($reports) {
         $reports |% { $_.FullName } |% {
             # In addition to replacing {reporoot}, we also normalize on one kind of slash so that the report aggregates data for a file whether data was collected on Windows or not.
-            $xml = [xml](Get-Content -Path $_)
+            $xml = [xml](Get-Content -LiteralPath $_)
             $xml.coverage.packages.package.classes.class |? { $_.filename} |% {
                 $_.filename = $_.filename.Replace('{reporoot}', $RepoRoot).Replace([IO.Path]::AltDirectorySeparatorChar, [IO.Path]::DirectorySeparatorChar)
             }

--- a/azure-pipelines/artifacts/Variables.ps1
+++ b/azure-pipelines/artifacts/Variables.ps1
@@ -32,10 +32,10 @@ Get-ChildItem "$PSScriptRoot/../variables" |% {
 
     # If that didn't get us anything, just copy the script itself
     if (-not $value) {
-        $value = Get-Content -Path $_.FullName
+        $value = Get-Content -LiteralPath $_.FullName
     }
 
-    Set-Content -Path "$VariablesArtifactPath/$($_.Name)" -Value $value
+    Set-Content -LiteralPath "$VariablesArtifactPath/$($_.Name)" -Value $value
 }
 
 @{

--- a/azure-pipelines/artifacts/_pipelines.ps1
+++ b/azure-pipelines/artifacts/_pipelines.ps1
@@ -16,7 +16,7 @@ Function Set-PipelineVariable($name, $value) {
         return # already set
     }
 
-    #New-Item -Path "Env:\$name".ToUpper() -Value $value -Force | Out-Null
+    #New-Item -LiteralPath "Env:\$name".ToUpper() -Value $value -Force | Out-Null
     Write-Host "##vso[task.setvariable variable=$name]$value"
 }
 

--- a/azure-pipelines/artifacts/_stage_all.ps1
+++ b/azure-pipelines/artifacts/_stage_all.ps1
@@ -51,7 +51,7 @@ $Artifacts |% {
     if (Test-Path -PathType Leaf $_.Source) { # skip folders
         $TargetPath = Join-Path $DestinationFolder $Name
         if ($AvoidSymbolicLinks) {
-            Copy-Item -Path $_.Source -Destination $TargetPath
+            Copy-Item -LiteralPath $_.Source -Destination $TargetPath
         } else {
             Create-SymbolicLink -Link $TargetPath -Target $_.Source
         }

--- a/azure-pipelines/artifacts/coverageResults.ps1
+++ b/azure-pipelines/artifacts/coverageResults.ps1
@@ -6,8 +6,8 @@ $coverageFiles = @(Get-ChildItem "$RepoRoot/test/*.cobertura.xml" -Recurse | Whe
 if ($env:SYSTEM_DEFAULTWORKINGDIRECTORY) {
     Write-Host "Substituting $env:SYSTEM_DEFAULTWORKINGDIRECTORY with `"{reporoot}`""
     $coverageFiles |% {
-        $content = Get-Content -Path $_ |% { $_ -Replace [regex]::Escape($env:SYSTEM_DEFAULTWORKINGDIRECTORY), "{reporoot}" }
-        Set-Content -Path $_ -Value $content -Encoding UTF8
+        $content = Get-Content -LiteralPath $_ |% { $_ -Replace [regex]::Escape($env:SYSTEM_DEFAULTWORKINGDIRECTORY), "{reporoot}" }
+        Set-Content -LiteralPath $_ -Value $content -Encoding UTF8
     }
 } else {
     Write-Warning "coverageResults: Azure Pipelines not detected. Machine-neutral token replacement skipped."

--- a/azure-pipelines/dotnet-test-cloud.ps1
+++ b/azure-pipelines/dotnet-test-cloud.ps1
@@ -61,7 +61,7 @@ Get-ChildItem -Recurse -Path $RepoRoot\test\*.trx |% {
   Copy-Item $_ -Destination $ArtifactStagingFolder/test_logs/
 
   if ($PublishResults) {
-    $x = [xml](Get-Content -Path $_)
+    $x = [xml](Get-Content -LiteralPath $_)
     $runTitle = $null
     if ($x.TestRun.TestDefinitions -and $x.TestRun.TestDefinitions.GetElementsByTagName('UnitTest')) {
       $storage = $x.TestRun.TestDefinitions.GetElementsByTagName('UnitTest')[0].storage -replace '\\','/'

--- a/azure-pipelines/publish-CodeCov.ps1
+++ b/azure-pipelines/publish-CodeCov.ps1
@@ -22,7 +22,7 @@ Param (
 
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 
-Get-ChildItem -Recurse -Path $PathToCodeCoverage -Filter "*.cobertura.xml" | % {
+Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml" | % {
     $relativeFilePath = Resolve-Path -relative $_.FullName
 
     Write-Host "Uploading: $relativeFilePath" -ForegroundColor Yellow

--- a/azure-pipelines/variables/DotNetSdkVersion.ps1
+++ b/azure-pipelines/variables/DotNetSdkVersion.ps1
@@ -1,2 +1,2 @@
-$globalJson = Get-Content -Path "$PSScriptRoot\..\..\global.json" | ConvertFrom-Json
+$globalJson = Get-Content -LiteralPath "$PSScriptRoot\..\..\global.json" | ConvertFrom-Json
 $globalJson.sdk.version

--- a/azure-pipelines/variables/_pipelines.ps1
+++ b/azure-pipelines/variables/_pipelines.ps1
@@ -24,8 +24,8 @@ param (
             # and the second that works across jobs and stages but must be fully qualified when referenced.
             Write-Host "##vso[task.setvariable variable=$keyCaps;isOutput=true]$($_.Value)"
         } elseif ($env:GITHUB_ACTIONS) {
-            Add-Content -Path $env:GITHUB_ENV -Value "$keyCaps=$($_.Value)"
+            Add-Content -LiteralPath $env:GITHUB_ENV -Value "$keyCaps=$($_.Value)"
         }
-        Set-Item -Path "env:$keyCaps" -Value $_.Value
+        Set-Item -LiteralPath "env:$keyCaps" -Value $_.Value
     }
 }

--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" PrivateAssets="build;analyzers;compile" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />
-    <PackageReference Include="PolySharp" PrivateAssets="all" />
     <PackageReference Include="System.IO.Pipelines" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -55,8 +55,8 @@ $runtimeVersions = @()
 $windowsDesktopRuntimeVersions = @()
 $aspnetRuntimeVersions = @()
 if (!$SdkOnly) {
-    Get-ChildItem "$PSScriptRoot\..\src\*.*proj","$PSScriptRoot\..\test\*.*proj","$PSScriptRoot\..\Directory.Build.props" -Recurse |% {
-        $projXml = [xml](Get-Content -Path $_)
+    Get-ChildItem "$PSScriptRoot\..\src\*.*proj", "$PSScriptRoot\..\test\*.*proj", "$PSScriptRoot\..\Directory.Build.props" -Recurse | % {
+        $projXml = [xml](Get-Content -LiteralPath $_)
         $pg = $projXml.Project.PropertyGroup
         if ($pg) {
             $targetFrameworks = @()

--- a/tools/Install-NuGetCredProvider.ps1
+++ b/tools/Install-NuGetCredProvider.ps1
@@ -50,7 +50,7 @@ if ($AccessToken) {
 
     $endpointURIs = @()
     Get-ChildItem "$PSScriptRoot\..\nuget.config" -Recurse |% {
-        $nugetConfig = [xml](Get-Content -Path $_)
+        $nugetConfig = [xml](Get-Content -LiteralPath $_)
 
         $nugetConfig.configuration.packageSources.add |? { ($_.value -match '^https://pkgs\.dev\.azure\.com/') -or ($_.value -match '^https://[\w\-]+\.pkgs\.visualstudio\.com/') } |% {
             if ($endpointURIs -notcontains $_.Value) {

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -45,14 +45,14 @@ if ($env:GITHUB_ACTIONS) {
 
 $CmdEnvScript = ''
 $Variables.GetEnumerator() |% {
-    Set-Item -Path env:$($_.Key) -Value $_.Value
+    Set-Item -LiteralPath env:$($_.Key) -Value $_.Value
 
     # If we're running in a cloud CI, set these environment variables so they propagate.
     if ($env:TF_BUILD) {
         Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
     }
     if ($env:GITHUB_ACTIONS) {
-        Add-Content -Path $env:GITHUB_ENV -Value "$($_.Key)=$($_.Value)"
+        Add-Content -LiteralPath $env:GITHUB_ENV -Value "$($_.Key)=$($_.Value)"
     }
 
     if ($cmdInstructions) {
@@ -70,7 +70,7 @@ if ($IsMacOS -or $IsLinux) {
 if ($PrependPath) {
     $PrependPath |% {
         $newPathValue = "$_$pathDelimiter$env:PATH"
-        Set-Item -Path env:PATH -Value $newPathValue
+        Set-Item -LiteralPath env:PATH -Value $newPathValue
         if ($cmdInstructions) {
             Write-Host "SET PATH=$newPathValue"
         }
@@ -79,7 +79,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-Content -Path $env:GITHUB_PATH -Value $_
+            Add-Content -LiteralPath $env:GITHUB_PATH -Value $_
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"
@@ -88,10 +88,10 @@ if ($PrependPath) {
 
 if ($env:CmdEnvScriptPath) {
     if (Test-Path $env:CmdEnvScriptPath) {
-        $CmdEnvScript = (Get-Content -Path $env:CmdEnvScriptPath) + $CmdEnvScript
+        $CmdEnvScript = (Get-Content -LiteralPath $env:CmdEnvScriptPath) + $CmdEnvScript
     }
 
-    Set-Content -Path $env:CmdEnvScriptPath -Value $CmdEnvScript
+    Set-Content -LiteralPath $env:CmdEnvScriptPath -Value $CmdEnvScript
 }
 
 return !$cmdInstructions


### PR DESCRIPTION
- Get dependabot to help us keep the .NET SDK current
- Bump docfx from 2.78.0 to 2.78.1 (#313)
- Bump Microsoft.NET.Test.Sdk from 17.11.1 to 17.12.0 (#312)
- Use `-LiteralPath` instead of `-Path` in ps1 scripts
- Replace `Nullable` with `PolySharp` as a dependency
