### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,21 +10,21 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.12.6",
+      "version": "17.13.1",
       "commands": [
         "dotnet-coverage"
       ],
       "rollForward": false
     },
     "nbgv": {
-      "version": "3.6.146",
+      "version": "3.7.112",
       "commands": [
         "nbgv"
       ],
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.1",
+      "version": "2.78.2",
       "commands": [
         "docfx"
       ],

--- a/.github/actions/publish-artifacts/action.yaml
+++ b/.github/actions/publish-artifacts/action.yaml
@@ -1,0 +1,67 @@
+name: Publish artifacts
+description: Publish artifacts
+
+runs:
+  using: composite
+  steps:
+  - name: 📥 Collect artifacts
+    run: azure-pipelines/artifacts/_stage_all.ps1
+    shell: pwsh
+    if: always()
+
+# TODO: replace this hard-coded list with a loop that utilizes the NPM package at
+# https://github.com/actions/toolkit/tree/main/packages/artifact (or similar) to push the artifacts.
+
+  - name: 📢 Upload project.assets.json files
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: projectAssetsJson-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/projectAssetsJson
+    continue-on-error: true
+  - name: 📢 Upload variables
+    uses: actions/upload-artifact@v4
+    with:
+      name: variables-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/Variables
+    continue-on-error: true
+  - name: 📢 Upload build_logs
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: build_logs-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/build_logs
+    continue-on-error: true
+  - name: 📢 Upload test_logs
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: test_logs-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/test_logs
+    continue-on-error: true
+  - name: 📢 Upload testResults
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: testResults-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/testResults
+    continue-on-error: true
+  - name: 📢 Upload coverageResults
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: coverageResults-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/coverageResults
+    continue-on-error: true
+  - name: 📢 Upload symbols
+    uses: actions/upload-artifact@v4
+    with:
+      name: symbols-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/symbols
+    continue-on-error: true
+  - name: 📢 Upload deployables
+    uses: actions/upload-artifact@v4
+    with:
+      name: deployables-${{ runner.os }}
+      path: ${{ runner.temp }}/_artifacts/deployables
+    if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ permissions:
   actions: read
   pages: write
   id-token: write
+  contents: read
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -26,6 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         submodules: true
     - name: ⚙ Install prerequisites
       run: ./init.ps1 -UpgradePrerequisites

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -1,4 +1,4 @@
-name: Library.Template update
+name: ⛜ Library.Template update
 
 # PREREQUISITE: This workflow requires the repo to be configured to allow workflows to create pull requests.
 # Visit https://github.com/USER/REPO/settings/actions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,29 @@ Please review the [CONTRIBUTING.md](src/nerdbank-streams/CONTRIBUTING.md) docume
 
 [pwsh]: https://docs.microsoft.com/powershell/scripting/install/installing-powershell?view=powershell-6
 
+## Releases
+
+Use `nbgv tag` to create a tag for a particular commit that you mean to release.
+[Learn more about `nbgv` and its `tag` and `prepare-release` commands](https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/nbgv-cli.md).
+
+Push the tag.
+
+### GitHub Actions
+
+When your repo is hosted by GitHub and you are using GitHub Actions, you should create a GitHub Release using the standard GitHub UI.
+Having previously used `nbgv tag` and pushing the tag will help you identify the precise commit and name to use for this release.
+
+After publishing the release, the `.github\workflows\release.yml` workflow will be automatically triggered, which will:
+
+1. Find the most recent `.github\workflows\build.yml` GitHub workflow run of the tagged release.
+1. Upload the `deployables` artifact from that workflow run to your GitHub Release.
+1. If you have `NUGET_API_KEY` defined as a secret variable for your repo or org, any nuget packages in the `deployables` artifact will be pushed to nuget.org.
+
+### Azure Pipelines
+
+When your repo builds with Azure Pipelines, use the `azure-pipelines/release.yml` pipeline.
+Trigger the pipeline by adding the `auto-release` tag on a run of your main `azure-pipelines.yml` pipeline.
+
 ## Tutorial and API documentation
 
 API and hand-written docs are found under the `docfx/` directory. and are built by [docfx](https://dotnet.github.io/docfx/).

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.7.112" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />
     <GlobalPackageReference Include="PolySharp" Version="1.15.0" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/azure-pipelines/artifacts/coverageResults.ps1
+++ b/azure-pipelines/artifacts/coverageResults.ps1
@@ -3,14 +3,16 @@ $RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
 $coverageFiles = @(Get-ChildItem "$RepoRoot/test/*.cobertura.xml" -Recurse | Where {$_.FullName -notlike "*/In/*"  -and $_.FullName -notlike "*\In\*" })
 
 # Prepare code coverage reports for merging on another machine
-if ($env:SYSTEM_DEFAULTWORKINGDIRECTORY) {
-    Write-Host "Substituting $env:SYSTEM_DEFAULTWORKINGDIRECTORY with `"{reporoot}`""
+$repoRoot = $env:SYSTEM_DEFAULTWORKINGDIRECTORY
+if (!$repoRoot) { $repoRoot = $env:GITHUB_WORKSPACE }
+if ($repoRoot) {
+    Write-Host "Substituting $repoRoot with `"{reporoot}`""
     $coverageFiles |% {
-        $content = Get-Content -LiteralPath $_ |% { $_ -Replace [regex]::Escape($env:SYSTEM_DEFAULTWORKINGDIRECTORY), "{reporoot}" }
+        $content = Get-Content -LiteralPath $_ |% { $_ -Replace [regex]::Escape($repoRoot), "{reporoot}" }
         Set-Content -LiteralPath $_ -Value $content -Encoding UTF8
     }
 } else {
-    Write-Warning "coverageResults: Azure Pipelines not detected. Machine-neutral token replacement skipped."
+    Write-Warning "coverageResults: Cloud build not detected. Machine-neutral token replacement skipped."
 }
 
 if (!((Test-Path $RepoRoot\bin) -and (Test-Path $RepoRoot\obj))) { return }

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -6,4 +6,4 @@ _layout: landing
 
 Nerdbank.Streams is a .NET library with a collection of APIs to make using the streaming/pipelines/buffers APIs of .NET easier.
 
-Click "Docs" across the top to get get started.
+Click "Docs" across the top to get started.


### PR DESCRIPTION
- **Add docfx verification to build**
- **Fix nb.gv failure during docfx build**
- **Remove double word from boilerplate docfx text**
- **Bump docfx to 2.78.2**
- **Bump dotnet-coverage to 17.13.1**
- **Move artifact publishing into a composite action**
- **Make the CI workflow dispatchable**
- **Fix docfx build on private repos**
- **Fix code coverage merge on GitHub Actions**
- **Add release workflow**
- **Document release process**
- **Publish test results when they fail on github workflows**
- **Fix push to nuget.org in github release workflow**
- **Bump nbgv and Nerdbank.GitVersioning to 3.7.112**
