### PR TITLE
Fix `DidReadSpan` and `DidReadMemory` events on `MonitoringStream` to not over-report buffer read

### DIFF
--- a/src/Nerdbank.Streams/MonitoringStream.cs
+++ b/src/Nerdbank.Streams/MonitoringStream.cs
@@ -5,7 +5,6 @@ namespace Nerdbank.Streams
 {
     using System;
     using System.IO;
-    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft;
@@ -253,7 +252,7 @@ namespace Nerdbank.Streams
         {
             this.WillReadSpan?.Invoke(this, buffer);
             int bytesRead = this.inner.Read(buffer);
-            this.DidReadSpan?.Invoke(this, buffer);
+            this.DidReadSpan?.Invoke(this, buffer[..bytesRead]);
             this.RaiseEndOfStreamIfNecessary(bytesRead);
             return bytesRead;
         }
@@ -263,7 +262,7 @@ namespace Nerdbank.Streams
         {
             this.WillReadMemory?.Invoke(this, buffer);
             int bytesRead = await this.inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-            this.DidReadMemory?.Invoke(this, buffer);
+            this.DidReadMemory?.Invoke(this, buffer[..bytesRead]);
             this.RaiseEndOfStreamIfNecessary(bytesRead);
             return bytesRead;
         }

--- a/test/Nerdbank.Streams.Tests/MonitoringStreamTests.cs
+++ b/test/Nerdbank.Streams.Tests/MonitoringStreamTests.cs
@@ -443,7 +443,7 @@ public class MonitoringStreamTests : TestBase
             didReadInvoked = true;
             Assert.True(willReadInvoked);
             Assert.Same(this.monitoringStream, s);
-            Assert.Equal(6, e.Length);
+            Assert.Equal(5, e.Length);
         };
         this.monitoringStream.DidRead += (s, e) => Assert.Fail("Unexpected event.");
         this.monitoringStream.DidReadMemory += (s, e) => Assert.Fail("Unexpected event.");
@@ -488,7 +488,7 @@ public class MonitoringStreamTests : TestBase
             didReadInvoked = true;
             Assert.True(willReadInvoked);
             Assert.Same(this.monitoringStream, s);
-            Assert.Equal(6, e.Length);
+            Assert.Equal(5, e.Length);
         };
         this.monitoringStream.DidRead += (s, e) => Assert.Fail("Unexpected event.");
         this.monitoringStream.DidReadSpan += (s, e) => Assert.Fail("Unexpected event.");


### PR DESCRIPTION
Fixes #854