### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.13.1",
+      "version": "17.14.2",
       "commands": [
         "dotnet-coverage"
       ],
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "docfx": {
-      "version": "2.78.2",
+      "version": "2.78.3",
       "commands": [
         "docfx"
       ],

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:9.0.102-noble
+FROM mcr.microsoft.com/dotnet/sdk:9.0.200-noble
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,6 +18,10 @@
 			"groupName": "Dockerfile and global.json updates"
 		},
 		{
+			"matchPackageNames": ["*"],
+			"allowedVersions": "!/-g[a-f0-9]+$/"
+		},
+		{
 			"matchPackageNames": [
 				"Microsoft.Bcl.AsyncInterfaces",
 				"System.Collections.Immutable",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: 🔗 Markup Link Checker (mlc)
-      uses: becheran/mlc@v0.19.0
+      uses: becheran/mlc@v0.21.0
       with:
-        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx
+        args: --do-not-warn-for-redirect-to https://learn.microsoft.com*,https://dotnet.microsoft.com/*,https://dev.azure.com/*,https://app.codecov.io/* -p docfx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,13 +26,13 @@
     <PackageVersion Include="System.IO.Pipes" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="1.0.1" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="1.1.0" />
     <PackageVersion Include="xunit.combinatorial" Version="2.0.24" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
-    <PackageVersion Include="xunit.v3" Version="1.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageVersion Include="xunit.v3" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.102",
+    "version": "9.0.200",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/tools/Get-NuGetTool.ps1
+++ b/tools/Get-NuGetTool.ps1
@@ -6,7 +6,7 @@
 #>
 Param(
     [Parameter()]
-    [string]$NuGetVersion='6.4.0'
+    [string]$NuGetVersion='6.12.2'
 )
 
 $toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"


### PR DESCRIPTION
- Bump nuget.exe build tool to 6.12.2
- Update becheran/mlc action to v0.19.1
- Suppress an expected doc warning
- Update becheran/mlc action to v0.19.2
- Renovate should not update to versions from non-release branches
- Drop group name in renovate
- Update xunit
- Update becheran/mlc action to v0.21.0
- Update dependency Microsoft.NET.Test.Sdk to 17.13.0 
- Update Dockerfile and global.json updates to v9.0.200
- Update dependency dotnet-coverage to 17.14.1
- Update dependency docfx to 2.78.3
- Update dependency dotnet-coverage to 17.14.2
