### PR TITLE
[EXPERIMENTAL] Generated unit tests

### DIFF
--- a/test/Nerdbank.Streams.Tests/ExtensionHeaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/ExtensionHeaderTests.cs
@@ -1,0 +1,119 @@
+using MessagePack;
+using System;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="ExtensionHeader"/> struct.
+    /// </summary>
+    public class ExtensionHeaderTests
+    {
+        /// <summary>
+        /// Tests that the constructor ExtensionHeader(sbyte, uint) correctly sets the TypeCode and Length properties.
+        /// </summary>
+        [Fact]
+        public void Ctor_WithUintLength_SetsProperties()
+        {
+            // Arrange
+            sbyte typeCode = 5;
+            uint length = 100;
+
+            // Act
+            var header = new ExtensionHeader(typeCode, length);
+
+            // Assert
+            Assert.Equal(typeCode, header.TypeCode);
+            Assert.Equal(length, header.Length);
+        }
+
+        /// <summary>
+        /// Tests that the constructor ExtensionHeader(sbyte, int) correctly sets the TypeCode and Length properties when given a positive integer.
+        /// </summary>
+        [Fact]
+        public void Ctor_WithIntLength_PositiveValue_SetsProperties()
+        {
+            // Arrange
+            sbyte typeCode = -10;
+            int length = 200;
+
+            // Act
+            var header = new ExtensionHeader(typeCode, length);
+
+            // Assert
+            Assert.Equal(typeCode, header.TypeCode);
+            Assert.Equal((uint)length, header.Length);
+        }
+
+        /// <summary>
+        /// Tests that the constructor ExtensionHeader(sbyte, int) correctly handles a negative integer by converting it to uint.
+        /// This edge case demonstrates the conversion of a negative integer to its corresponding unsigned value.
+        /// </summary>
+        [Fact]
+        public void Ctor_WithIntLength_NegativeValue_ConvertsToUint()
+        {
+            // Arrange
+            sbyte typeCode = 1;
+            int negativeLength = -1;
+            uint expectedLength = unchecked((uint)negativeLength);
+
+            // Act
+            var header = new ExtensionHeader(typeCode, negativeLength);
+
+            // Assert
+            Assert.Equal(typeCode, header.TypeCode);
+            Assert.Equal(expectedLength, header.Length);
+        }
+
+        /// <summary>
+        /// Tests that the Equals method returns true when comparing two ExtensionHeader instances with identical TypeCode and Length.
+        /// </summary>
+        [Fact]
+        public void Equals_SameValues_ReturnsTrue()
+        {
+            // Arrange
+            var header1 = new ExtensionHeader(10, 500);
+            var header2 = new ExtensionHeader(10, 500);
+
+            // Act
+            bool areEqual = header1.Equals(header2);
+
+            // Assert
+            Assert.True(areEqual, "Equals should return true for headers with identical values.");
+        }
+
+        /// <summary>
+        /// Tests that the Equals method returns false when comparing two ExtensionHeader instances with different TypeCode values.
+        /// </summary>
+        [Fact]
+        public void Equals_DifferentTypeCode_ReturnsFalse()
+        {
+            // Arrange
+            var header1 = new ExtensionHeader(10, 500);
+            var header2 = new ExtensionHeader(11, 500);
+
+            // Act
+            bool areEqual = header1.Equals(header2);
+
+            // Assert
+            Assert.False(areEqual, "Equals should return false for headers with different TypeCode values.");
+        }
+
+        /// <summary>
+        /// Tests that the Equals method returns false when comparing two ExtensionHeader instances with different Length values.
+        /// </summary>
+        [Fact]
+        public void Equals_DifferentLength_ReturnsFalse()
+        {
+            // Arrange
+            var header1 = new ExtensionHeader(10, 500);
+            var header2 = new ExtensionHeader(10, 600);
+
+            // Act
+            bool areEqual = header1.Equals(header2);
+
+            // Assert
+            Assert.False(areEqual, "Equals should return false for headers with different Length values.");
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/ExtensionResultTests.cs
+++ b/test/Nerdbank.Streams.Tests/ExtensionResultTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Buffers;
+using MessagePack;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="ExtensionResult"/> struct.
+    /// </summary>
+    public class ExtensionResultTests
+    {
+        /// <summary>
+        /// Tests that the constructor accepting Memory&lt;byte&gt; sets the properties correctly.
+        /// </summary>
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        [InlineData(127)]
+        public void Constructor_WithMemoryByte_SetsPropertiesCorrectly(sbyte typeCode)
+        {
+            // Arrange
+            byte[] testData = { 1, 2, 3, 4, 5 };
+            Memory<byte> memoryData = new Memory<byte>(testData);
+            
+            // Act
+            var result = new ExtensionResult(typeCode, memoryData);
+
+            // Assert
+            Assert.Equal(typeCode, result.TypeCode);
+            // Comparing lengths as ReadOnlySequence<byte> does not expose array directly, so check the length.
+            Assert.Equal(testData.Length, result.Data.Length);
+        }
+
+        /// <summary>
+        /// Tests that the constructor accepting ReadOnlySequence&lt;byte&gt; sets the properties correctly.
+        /// </summary>
+        [Theory]
+        [InlineData(-10)]
+        [InlineData(5)]
+        public void Constructor_WithReadOnlySequence_SetsPropertiesCorrectly(sbyte typeCode)
+        {
+            // Arrange
+            byte[] testData = { 10, 20, 30 };
+            ReadOnlySequence<byte> sequenceData = new ReadOnlySequence<byte>(testData);
+
+            // Act
+            var result = new ExtensionResult(typeCode, sequenceData);
+
+            // Assert
+            Assert.Equal(typeCode, result.TypeCode);
+            Assert.Equal(testData.Length, result.Data.Length);
+        }
+
+        /// <summary>
+        /// Tests that the Header property returns an ExtensionHeader with the correct type code and length.
+        /// </summary>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(-5)]
+        public void HeaderProperty_WhenInvoked_ReturnsCorrectExtensionHeader(sbyte typeCode)
+        {
+            // Arrange
+            byte[] testData = { 100, 101, 102, 103 };
+            Memory<byte> memoryData = new Memory<byte>(testData);
+            var result = new ExtensionResult(typeCode, memoryData);
+            uint expectedLength = (uint)testData.Length;
+
+            // Act
+            var header = result.Header;
+
+            // Assert
+            // Since ExtensionHeader is constructed as new ExtensionHeader(typeCode, length)
+            // and we do not have its internal implementation, we assume it exposes the TypeCode and Length properties.
+            // We perform the check by comparing the values with a newly constructed header.
+            var expectedHeader = new ExtensionHeader(typeCode, expectedLength);
+            Assert.Equal(expectedHeader.TypeCode, header.TypeCode);
+            Assert.Equal(expectedHeader.Length, header.Length);
+        }
+
+        /// <summary>
+        /// Tests the behavior when handling an empty Memory&lt;byte&gt;.
+        /// </summary>
+        [Fact]
+        public void Constructor_WithEmptyMemory_SetsPropertiesCorrectly()
+        {
+            // Arrange
+            sbyte typeCode = 10;
+            Memory<byte> emptyMemory = Memory<byte>.Empty;
+
+            // Act
+            var result = new ExtensionResult(typeCode, emptyMemory);
+
+            // Assert
+            Assert.Equal(typeCode, result.TypeCode);
+            Assert.Equal(0, result.Data.Length);
+            var header = result.Header;
+            Assert.Equal(typeCode, header.TypeCode);
+            Assert.Equal((uint)0, header.Length);
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/FullDuplexStreamTests.cs
+++ b/test/Nerdbank.Streams.Tests/FullDuplexStreamTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.IO;
+using System.IO.Pipelines;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="FullDuplexStream"/> class.
+    /// </summary>
+    public class FullDuplexStreamTests
+    {
+        /// <summary>
+        /// Verifies that CreatePair returns a pair of interconnected streams with full duplex communication.
+        /// The test writes data from one stream and validates that it is received by the paired stream, and vice versa.
+        /// </summary>
+        [Fact]
+        public async Task CreatePair_WhenCalled_ReturnsConnectedStreams()
+        {
+            // Arrange & Act
+            (Stream stream1, Stream stream2) = FullDuplexStream.CreatePair();
+
+            // Arrange message data for communication from stream1 to stream2.
+            byte[] messageFrom1 = Encoding.UTF8.GetBytes("Hello from stream1");
+            byte[] readBuffer1 = new byte[messageFrom1.Length];
+
+            // Act: Write data on stream1.
+            await stream1.WriteAsync(messageFrom1, 0, messageFrom1.Length);
+            await stream1.FlushAsync();
+            // Allow some time for internal propagation.
+            await Task.Delay(50);
+            int bytesRead1 = await stream2.ReadAsync(readBuffer1, 0, readBuffer1.Length);
+
+            // Assert: Verify that stream2 received the correct data.
+            Assert.Equal(messageFrom1.Length, bytesRead1);
+            Assert.Equal(messageFrom1, readBuffer1);
+
+            // Arrange message data for communication from stream2 to stream1.
+            byte[] messageFrom2 = Encoding.UTF8.GetBytes("Reply from stream2");
+            byte[] readBuffer2 = new byte[messageFrom2.Length];
+
+            // Act: Write data on stream2.
+            await stream2.WriteAsync(messageFrom2, 0, messageFrom2.Length);
+            await stream2.FlushAsync();
+            await Task.Delay(50);
+            int bytesRead2 = await stream1.ReadAsync(readBuffer2, 0, readBuffer2.Length);
+
+            // Assert: Verify that stream1 received the correct reply.
+            Assert.Equal(messageFrom2.Length, bytesRead2);
+            Assert.Equal(messageFrom2, readBuffer2);
+        }
+
+        /// <summary>
+        /// Verifies that CreatePipePair returns a pair of interconnected IDuplexPipe objects.
+        /// The test converts the pipes to streams and performs bidirectional communication.
+        /// </summary>
+        [Fact]
+        public async Task CreatePipePair_WhenCalled_ReturnsConnectedPipePair()
+        {
+            // Arrange & Act
+            (IDuplexPipe pipe1, IDuplexPipe pipe2) = FullDuplexStream.CreatePipePair();
+
+            // Convert the duplex pipes to streams to test the I/O behavior.
+            Stream stream1 = pipe1.AsStream();
+            Stream stream2 = pipe2.AsStream();
+
+            // Arrange message data for communication from pipe1 to pipe2.
+            byte[] messageFromPipe1 = Encoding.UTF8.GetBytes("Hello from pipe1");
+            byte[] readBuffer1 = new byte[messageFromPipe1.Length];
+
+            // Act: Write data on stream1.
+            await stream1.WriteAsync(messageFromPipe1, 0, messageFromPipe1.Length);
+            await stream1.FlushAsync();
+            await Task.Delay(50);
+            int bytesRead1 = await stream2.ReadAsync(readBuffer1, 0, readBuffer1.Length);
+
+            // Assert: Validate that stream2 received correct data.
+            Assert.Equal(messageFromPipe1.Length, bytesRead1);
+            Assert.Equal(messageFromPipe1, readBuffer1);
+
+            // Arrange message data for communication from pipe2 to pipe1.
+            byte[] messageFromPipe2 = Encoding.UTF8.GetBytes("Reply from pipe2");
+            byte[] readBuffer2 = new byte[messageFromPipe2.Length];
+
+            // Act: Write data on stream2.
+            await stream2.WriteAsync(messageFromPipe2, 0, messageFromPipe2.Length);
+            await stream2.FlushAsync();
+            await Task.Delay(50);
+            int bytesRead2 = await stream1.ReadAsync(readBuffer2, 0, readBuffer2.Length);
+
+            // Assert: Validate that stream1 received the correct response.
+            Assert.Equal(messageFromPipe2.Length, bytesRead2);
+            Assert.Equal(messageFromPipe2, readBuffer2);
+        }
+
+        /// <summary>
+        /// Verifies that Splice correctly creates a full duplex stream from a readable stream and a writable stream.
+        /// The test confirms that data is correctly read from the provided readable stream and written to the writable stream.
+        /// Additionally, properties and disposal behavior are validated.
+        /// </summary>
+        [Fact]
+        public async Task Splice_WhenCalledWithValidStreams_ReadAndWriteWork()
+        {
+            // Arrange: Create a readable stream with preset content and an empty writable stream.
+            byte[] initialData = Encoding.UTF8.GetBytes("Initial data");
+            MemoryStream readable = new MemoryStream(initialData);
+            MemoryStream writable = new MemoryStream();
+
+            // Act: Create a spliced combined stream.
+            Stream combined = FullDuplexStream.Splice(readable, writable);
+
+            // Act: Reading from the combined stream should return the underlying readable stream's data.
+            byte[] readBuffer = new byte[initialData.Length];
+            int bytesRead = await combined.ReadAsync(readBuffer, 0, readBuffer.Length);
+
+            // Assert: Validate the read content.
+            Assert.Equal(initialData.Length, bytesRead);
+            Assert.Equal(initialData, readBuffer);
+
+            // Act: Writing to the combined stream should write to the underlying writable stream.
+            byte[] newData = Encoding.UTF8.GetBytes("New data");
+            await combined.WriteAsync(newData, 0, newData.Length);
+            combined.Flush();
+            // Reset writable stream's position to verify written data.
+            writable.Position = 0;
+            byte[] writeBuffer = new byte[newData.Length];
+            int bytesWritten = await writable.ReadAsync(writeBuffer, 0, writeBuffer.Length);
+
+            // Assert: Validate the written content.
+            Assert.Equal(newData.Length, bytesWritten);
+            Assert.Equal(newData, writeBuffer);
+
+            // Verify properties before disposal.
+            Assert.True(combined.CanRead);
+            Assert.True(combined.CanWrite);
+
+            // Act: Dispose the combined stream.
+            combined.Dispose();
+
+            // Verify properties after disposal.
+            Assert.False(combined.CanRead);
+            Assert.False(combined.CanWrite);
+
+            // Assert: Subsequent read and write operations should throw ObjectDisposedException.
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await combined.ReadAsync(new byte[1], 0, 1));
+            await Assert.ThrowsAsync<ObjectDisposedException>(async () => await combined.WriteAsync(new byte[1], 0, 1));
+        }
+
+        /// <summary>
+        /// Verifies that Splice throws an ArgumentNullException when the readable stream is null.
+        /// </summary>
+        [Fact]
+        public void Splice_NullReadableStream_ThrowsArgumentNullException()
+        {
+            // Arrange: Prepare a valid writable stream.
+            MemoryStream writable = new MemoryStream();
+
+            // Act & Assert: Expect ArgumentNullException when the readable stream is null.
+            Assert.Throws<ArgumentNullException>(() => FullDuplexStream.Splice(null, writable));
+        }
+
+        /// <summary>
+        /// Verifies that Splice throws an ArgumentNullException when the writable stream is null.
+        /// </summary>
+        [Fact]
+        public void Splice_NullWritableStream_ThrowsArgumentNullException()
+        {
+            // Arrange: Prepare a valid readable stream.
+            MemoryStream readable = new MemoryStream();
+
+            // Act & Assert: Expect ArgumentNullException when the writable stream is null.
+            Assert.Throws<ArgumentNullException>(() => FullDuplexStream.Splice(readable, null));
+        }
+
+        /// <summary>
+        /// Verifies that Splice throws an ArgumentException when the provided readable stream is not readable.
+        /// </summary>
+        [Fact]
+        public void Splice_NonReadableStream_ThrowsArgumentException()
+        {
+            // Arrange: Create a stream that reports CanRead as false.
+            Stream nonReadable = new NonReadableStream();
+            MemoryStream writable = new MemoryStream();
+
+            // Act & Assert: Expect ArgumentException with a message indicating the stream must be readable.
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => FullDuplexStream.Splice(nonReadable, writable));
+            Assert.Contains("Must be readable", ex.Message);
+        }
+
+        /// <summary>
+        /// Verifies that Splice throws an ArgumentException when the provided writable stream is not writable.
+        /// </summary>
+        [Fact]
+        public void Splice_NonWritableStream_ThrowsArgumentException()
+        {
+            // Arrange: Create a stream that reports CanWrite as false.
+            MemoryStream readable = new MemoryStream(new byte[] { 1, 2, 3 });
+            Stream nonWritable = new NonWritableStream();
+
+            // Act & Assert: Expect ArgumentException with a message indicating the stream must be writable.
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => FullDuplexStream.Splice(readable, nonWritable));
+            Assert.Contains("Must be writable", ex.Message);
+        }
+
+        /// <summary>
+        /// A helper stream that simulates a non-readable stream by overriding CanRead to false.
+        /// </summary>
+        private class NonReadableStream : MemoryStream
+        {
+            public override bool CanRead => false;
+        }
+
+        /// <summary>
+        /// A helper stream that simulates a non-writable stream by overriding CanWrite to false.
+        /// </summary>
+        private class NonWritableStream : MemoryStream
+        {
+            public override bool CanWrite => false;
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/GuidBitsTests.cs
+++ b/test/Nerdbank.Streams.Tests/GuidBitsTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Text;
+using MessagePack.Internal;
+using Xunit;
+
+namespace MessagePack.Internal.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="GuidBits"/> struct.
+    /// </summary>
+    public class GuidBitsTests
+    {
+        /// <summary>
+        /// Tests that constructing GuidBits via the ref Guid constructor and writing its value produces the expected GUID string.
+        /// </summary>
+//         [Fact] [Error] (22-13)CS0122 'GuidBits' is inaccessible due to its protection level [Error] (22-37)CS0122 'GuidBits' is inaccessible due to its protection level
+//         public void Write_FromRefConstructor_ReturnsCorrectGuidString()
+//         {
+//             // Arrange
+//             Guid expectedGuid = new Guid("00112233-4455-6677-8899-aabbccddeeff");
+//             Guid guid = expectedGuid;
+//             GuidBits guidBits = new GuidBits(ref guid);
+//             byte[] buffer = new byte[36];
+// 
+//             // Act
+//             guidBits.Write(buffer);
+//             string result = Encoding.ASCII.GetString(buffer);
+// 
+//             // Assert
+//             Assert.Equal(expectedGuid.ToString("D"), result);
+//         }
+
+        /// <summary>
+        /// Tests that constructing GuidBits from a valid 32-digit GUID string creates a struct that writes out the expected GUID string.
+        /// </summary>
+//         [Fact] [Error] (43-13)CS0122 'GuidBits' is inaccessible due to its protection level [Error] (43-37)CS0122 'GuidBits' is inaccessible due to its protection level
+//         public void Constructor32DigitString_ValidInput_ReturnsExpectedGuid()
+//         {
+//             // Arrange
+//             string guidString32 = "00112233445566778899aabbccddeeff";
+//             byte[] inputBytes = Encoding.ASCII.GetBytes(guidString32);
+//             Guid expectedGuid = new Guid("00112233-4455-6677-8899-aabbccddeeff");
+//             GuidBits guidBits = new GuidBits(inputBytes);
+//             byte[] buffer = new byte[36];
+// 
+//             // Act
+//             guidBits.Write(buffer);
+//             string result = Encoding.ASCII.GetString(buffer);
+// 
+//             // Assert
+//             Assert.Equal(expectedGuid.ToString("D"), result);
+//         }
+
+        /// <summary>
+        /// Tests that constructing GuidBits from a valid 36-digit GUID string creates a struct that writes out the expected GUID string.
+        /// </summary>
+//         [Fact] [Error] (64-13)CS0122 'GuidBits' is inaccessible due to its protection level [Error] (64-37)CS0122 'GuidBits' is inaccessible due to its protection level
+//         public void Constructor36DigitString_ValidInput_ReturnsExpectedGuid()
+//         {
+//             // Arrange
+//             string guidString36 = "00112233-4455-6677-8899-aabbccddeeff";
+//             byte[] inputBytes = Encoding.ASCII.GetBytes(guidString36);
+//             Guid expectedGuid = new Guid(guidString36);
+//             GuidBits guidBits = new GuidBits(inputBytes);
+//             byte[] buffer = new byte[36];
+// 
+//             // Act
+//             guidBits.Write(buffer);
+//             string result = Encoding.ASCII.GetString(buffer);
+// 
+//             // Assert
+//             Assert.Equal(expectedGuid.ToString("D"), result);
+//         }
+
+        /// <summary>
+        /// Tests that constructing GuidBits with an input of invalid length throws a MessagePackSerializationException.
+        /// </summary>
+        /// <param name="invalidInput">An invalid GUID string input.</param>
+//         [Theory] [Error] (88-72)CS0122 'GuidBits' is inaccessible due to its protection level
+//         [InlineData("1234567890")]
+//         [InlineData("00112233-4455-6677-8899-aabbccddeef")]
+//         public void Constructor_InvalidLength_ThrowsMessagePackSerializationException(string invalidInput)
+//         {
+//             // Arrange
+//             byte[] inputBytes = Encoding.ASCII.GetBytes(invalidInput);
+// 
+//             // Act & Assert
+//             Assert.Throws<MessagePackSerializationException>(() => new GuidBits(inputBytes));
+//         }
+
+        /// <summary>
+        /// Tests that constructing GuidBits from a 36-digit GUID string with an invalid dash position throws a MessagePackSerializationException.
+        /// </summary>
+//         [Fact] [Error] (105-72)CS0122 'GuidBits' is inaccessible due to its protection level
+//         public void Constructor36_InvalidDashPosition_ThrowsMessagePackSerializationException()
+//         {
+//             // Arrange
+//             // Replace the expected dash at index 8 with an invalid character.
+//             char[] chars = "00112233-4455-6677-8899-aabbccddeeff".ToCharArray();
+//             chars[8] = 'X';
+//             string invalidGuidString = new string(chars);
+//             byte[] inputBytes = Encoding.ASCII.GetBytes(invalidGuidString);
+// 
+//             // Act & Assert
+//             Assert.Throws<MessagePackSerializationException>(() => new GuidBits(inputBytes));
+//         }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MessagePackCodeTests.cs
+++ b/test/Nerdbank.Streams.Tests/MessagePackCodeTests.cs
@@ -1,0 +1,141 @@
+using System;
+using MessagePack;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="MessagePackCode"/> class.
+    /// </summary>
+    public class MessagePackCodeTests
+    {
+        /// <summary>
+        /// Tests that MessagePackCode.ToMessagePackType returns the expected MessagePackType for given byte codes.
+        /// </summary>
+        /// <param name="code">The byte code to test.</param>
+        /// <param name="expectedType">The expected MessagePackType.</param>
+        [Theory]
+        [InlineData((byte)0, MessagePackType.Integer)]
+        [InlineData((byte)127, MessagePackType.Integer)]
+        [InlineData((byte)128, MessagePackType.Map)]
+        [InlineData((byte)143, MessagePackType.Map)]
+        [InlineData((byte)144, MessagePackType.Array)]
+        [InlineData((byte)159, MessagePackType.Array)]
+        [InlineData((byte)160, MessagePackType.String)]
+        [InlineData((byte)191, MessagePackType.String)]
+        [InlineData((byte)192, MessagePackType.Nil)]
+        [InlineData((byte)193, MessagePackType.Unknown)]
+        [InlineData((byte)194, MessagePackType.Boolean)]
+        [InlineData((byte)195, MessagePackType.Boolean)]
+        [InlineData((byte)208, MessagePackType.Integer)]
+        [InlineData((byte)209, MessagePackType.Integer)]
+        [InlineData((byte)210, MessagePackType.Integer)]
+        [InlineData((byte)211, MessagePackType.Integer)]
+        [InlineData((byte)224, MessagePackType.Integer)]
+        [InlineData((byte)255, MessagePackType.Integer)]
+        [InlineData((byte)217, MessagePackType.String)] // Str8
+        [InlineData((byte)218, MessagePackType.String)] // Str16
+        [InlineData((byte)219, MessagePackType.String)] // Str32
+        [InlineData((byte)220, MessagePackType.Array)]  // Array16
+        [InlineData((byte)221, MessagePackType.Array)]  // Array32
+        [InlineData((byte)222, MessagePackType.Map)]    // Map16
+        [InlineData((byte)223, MessagePackType.Map)]    // Map32
+        [InlineData((byte)196, MessagePackType.Binary)] // Bin8
+        [InlineData((byte)197, MessagePackType.Binary)] // Bin16
+        [InlineData((byte)198, MessagePackType.Binary)] // Bin32
+        [InlineData((byte)199, MessagePackType.Extension)] // Ext8
+        [InlineData((byte)200, MessagePackType.Extension)] // Ext16
+        [InlineData((byte)201, MessagePackType.Extension)] // Ext32
+        public void ToMessagePackType_ValidCode_ReturnsExpectedMessagePackType(byte code, MessagePackType expectedType)
+        {
+            // Act
+            MessagePackType result = MessagePackCode.ToMessagePackType(code);
+
+            // Assert
+            Assert.Equal(expectedType, result);
+        }
+
+        /// <summary>
+        /// Tests that MessagePackCode.ToFormatName returns the expected format name for given byte codes.
+        /// </summary>
+        /// <param name="code">The byte code to test.</param>
+        /// <param name="expectedFormatName">The expected format name.</param>
+        [Theory]
+        [InlineData((byte)0, "positive fixint")]
+        [InlineData((byte)127, "positive fixint")]
+        [InlineData((byte)128, "fixmap")]
+        [InlineData((byte)143, "fixmap")]
+        [InlineData((byte)144, "fixarray")]
+        [InlineData((byte)159, "fixarray")]
+        [InlineData((byte)160, "fixstr")]
+        [InlineData((byte)191, "fixstr")]
+        [InlineData((byte)192, "nil")]
+        [InlineData((byte)193, "(never used)")]
+        [InlineData((byte)194, "false")]
+        [InlineData((byte)195, "true")]
+        [InlineData((byte)208, "int 8")]
+        [InlineData((byte)209, "int 16")]
+        [InlineData((byte)210, "int 32")]
+        [InlineData((byte)211, "int 64")]
+        [InlineData((byte)224, "negative fixint")]
+        [InlineData((byte)255, "negative fixint")]
+        [InlineData((byte)217, "str 8")]
+        [InlineData((byte)218, "str 16")]
+        [InlineData((byte)219, "str 32")]
+        [InlineData((byte)220, "array 16")]
+        [InlineData((byte)221, "array 32")]
+        [InlineData((byte)222, "map 16")]
+        [InlineData((byte)223, "map 32")]
+        [InlineData((byte)196, "bin 8")]
+        [InlineData((byte)197, "bin 16")]
+        [InlineData((byte)198, "bin 32")]
+        [InlineData((byte)199, "ext 8")]
+        [InlineData((byte)200, "ext 16")]
+        [InlineData((byte)201, "ext 32")]
+        [InlineData((byte)202, "float 32")]
+        [InlineData((byte)203, "float 64")]
+        [InlineData((byte)204, "uint 8")]
+        [InlineData((byte)205, "uint 16")]
+        [InlineData((byte)206, "uint 32")]
+        [InlineData((byte)207, "uint 64")]
+        [InlineData((byte)212, "fixext 1")]
+        [InlineData((byte)213, "fixext 2")]
+        [InlineData((byte)214, "fixext 4")]
+        [InlineData((byte)215, "fixext 8")]
+        [InlineData((byte)216, "fixext 16")]
+        public void ToFormatName_ValidCode_ReturnsExpectedFormatName(byte code, string expectedFormatName)
+        {
+            // Act
+            string result = MessagePackCode.ToFormatName(code);
+
+            // Assert
+            Assert.Equal(expectedFormatName, result);
+        }
+
+        /// <summary>
+        /// Tests that MessagePackCode.IsSignedInteger returns true for codes representing signed integers and false for others.
+        /// </summary>
+        /// <param name="code">The byte code to test.</param>
+        /// <param name="expectedResult">The expected boolean result indicating if the code represents a signed integer.</param>
+//         [Theory] [Error] (135-43)CS0117 'MessagePackCode' does not contain a definition for 'IsSignedInteger'
+//         [InlineData((byte)208, true)]  // Int8
+//         [InlineData((byte)209, true)]  // Int16
+//         [InlineData((byte)210, true)]  // Int32
+//         [InlineData((byte)211, true)]  // Int64
+//         [InlineData((byte)225, true)]  // Negative fixint (>=224 and <=255)
+//         [InlineData((byte)255, true)]  // Negative fixint
+//         [InlineData((byte)127, false)] // Positive fixint not considered signed
+//         [InlineData((byte)192, false)] // Nil
+//         [InlineData((byte)217, false)] // str 8
+//         [InlineData((byte)0, false)]   // Positive fixint
+//         [InlineData((byte)223, false)] // map32 falls outside signed integer range
+//         public void IsSignedInteger_VariousCodes_ReturnsExpectedResult(byte code, bool expectedResult)
+//         {
+//             // Act
+//             bool result = MessagePackCode.IsSignedInteger(code);
+// 
+//             // Assert
+//             Assert.Equal(expectedResult, result);
+//         }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MessagePackSerializationExceptionTests.cs
+++ b/test/Nerdbank.Streams.Tests/MessagePackSerializationExceptionTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Runtime.Serialization;
+using MessagePack;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="MessagePackSerializationException"/> class.
+    /// </summary>
+    public class MessagePackSerializationExceptionTests
+    {
+        /// <summary>
+        /// Tests the parameterless constructor to ensure it creates an instance with the expected default values.
+        /// </summary>
+        [Fact]
+        public void ParameterlessConstructor_ShouldCreateInstanceWithNoInnerException()
+        {
+            // Arrange & Act
+            var exception = new MessagePackSerializationException();
+
+            // Assert
+            Assert.NotNull(exception);
+            // The default exception message can be system dependent so we check that it is not null or empty
+            Assert.False(string.IsNullOrEmpty(exception.Message));
+            Assert.Null(exception.InnerException);
+        }
+
+        /// <summary>
+        /// Tests the constructor accepting a message to ensure it correctly sets the Message property.
+        /// </summary>
+        [Fact]
+        public void ConstructorWithMessage_ShouldSetMessageProperty()
+        {
+            // Arrange
+            const string expectedMessage = "Test message";
+
+            // Act
+            var exception = new MessagePackSerializationException(expectedMessage);
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal(expectedMessage, exception.Message);
+            Assert.Null(exception.InnerException);
+        }
+
+        /// <summary>
+        /// Tests the constructor accepting a message and an inner exception to ensure both properties are set correctly.
+        /// </summary>
+        [Fact]
+        public void ConstructorWithMessageAndInnerException_ShouldSetProperties()
+        {
+            // Arrange
+            const string expectedMessage = "Test message";
+            var expectedInnerException = new Exception("Inner exception");
+
+            // Act
+            var exception = new MessagePackSerializationException(expectedMessage, expectedInnerException);
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal(expectedMessage, exception.Message);
+            Assert.Equal(expectedInnerException, exception.InnerException);
+        }
+
+        /// <summary>
+        /// Tests the protected deserialization constructor by using a derived class.
+        /// It verifies that the deserialized instance correctly retrieves the message from the SerializationInfo.
+        /// </summary>
+        [Fact]
+        public void ProtectedConstructor_WithSerializationInfo_ShouldDeserializeProperties()
+        {
+            // Arrange
+            const string serializedMessage = "Deserialized message";
+            var info = new SerializationInfo(typeof(MessagePackSerializationException), new FormatterConverter());
+            // Populate the SerializationInfo; note that Exception deserialization uses "Message" key.
+            info.AddValue("Message", serializedMessage);
+            info.AddValue("InnerException", null, typeof(Exception));
+            var context = new StreamingContext(StreamingContextStates.All);
+
+            // Act
+            var exception = new TestableMessagePackSerializationException(info, context);
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal(serializedMessage, exception.Message);
+            Assert.Null(exception.InnerException);
+        }
+
+        /// <summary>
+        /// A testable subclass to expose the protected deserialization constructor of <see cref="MessagePackSerializationException"/>.
+        /// </summary>
+        private class TestableMessagePackSerializationException : MessagePackSerializationException
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="TestableMessagePackSerializationException"/> class using serialization info and context.
+            /// </summary>
+            /// <param name="info">The SerializationInfo to use.</param>
+            /// <param name="context">The StreamingContext to use.</param>
+            public TestableMessagePackSerializationException(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+            {
+            }
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MessagePackStreamReaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/MessagePackStreamReaderTests.cs
@@ -1,0 +1,183 @@
+using MessagePack;
+using System;
+using System.Buffers;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref = "MessagePackStreamReader"/> class.
+    /// </summary>
+    public class MessagePackStreamReaderTests
+    {
+        /// <summary>
+        /// Tests that the constructor throws an ArgumentNullException when a null stream is passed.
+        /// </summary>
+        [Fact]
+        public void Constructor_WithNullStream_ThrowsArgumentNullException()
+        {
+            // Arrange, Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new MessagePackStreamReader(null));
+        }
+
+        /// <summary>
+        /// Tests that ReadAsync returns null when the underlying stream is empty.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_EmptyStream_ReturnsNull()
+        {
+            // Arrange
+            using var stream = new MemoryStream(Array.Empty<byte>());
+            using var reader = new MessagePackStreamReader(stream);
+            var cancellationToken = CancellationToken.None;
+            // Act
+            var result = await reader.ReadAsync(cancellationToken);
+            // Assert
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// Tests that ReadAsync throws an OperationCanceledException when the cancellation token is cancelled.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_WithCancellationRequested_ThrowsOperationCanceledException()
+        {
+            // Arrange
+            byte[] data = new byte[]
+            {
+                0xC0
+            };
+            using var stream = new MemoryStream(data);
+            using var reader = new MessagePackStreamReader(stream);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            // Act & Assert
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await reader.ReadAsync(cts.Token));
+        }
+
+        /// <summary>
+        /// Tests that ReadAsync successfully returns a complete message when available.
+        /// A message is simulated using a single byte (0xC0) representing a valid MessagePack "nil" message.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_WithCompleteMessage_ReturnsMessage()
+        {
+            // Arrange
+            byte[] message = new byte[]
+            {
+                0xC0
+            };
+            using var stream = new MemoryStream(message);
+            using var reader = new MessagePackStreamReader(stream);
+            var cancellationToken = CancellationToken.None;
+            // Act
+            var result = await reader.ReadAsync(cancellationToken);
+            // Assert
+            Assert.NotNull(result);
+            byte[] resultArray = result.Value.ToArray();
+            Assert.Equal(message, resultArray);
+        }
+
+        /// <summary>
+        /// Tests that when the underlying stream contains two consecutive messages, ReadAsync returns the first complete message and RemainingBytes reflects the next message.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_WithMultipleMessages_ReturnsFirstMessageAndRemainingDataCorrectly()
+        {
+            // Arrange
+            byte[] messages = new byte[]
+            {
+                0xC0,
+                0xC0
+            };
+            using var stream = new MemoryStream(messages);
+            using var reader = new MessagePackStreamReader(stream);
+            var cancellationToken = CancellationToken.None;
+            // Act
+            var firstMessage = await reader.ReadAsync(cancellationToken);
+            // Assert: First message matches the first byte.
+            Assert.NotNull(firstMessage);
+            byte[] firstMessageArray = firstMessage.Value.ToArray();
+            Assert.Equal(new byte[] { 0xC0 }, firstMessageArray);
+            // Verify RemainingBytes returns the second message.
+            ReadOnlyMemory<byte> remainingBytes = reader.RemainingBytes.ToArray();
+            Assert.Equal(new byte[] { 0xC0 }, remainingBytes.ToArray());
+        }
+
+        /// <summary>
+        /// Tests that DiscardBufferedData resets the internal buffer by clearing any buffered data.
+        /// </summary>
+        [Fact]
+        public async Task DiscardBufferedData_ResetsBuffer()
+        {
+            // Arrange
+            byte[] messages = new byte[]
+            {
+                0xC0,
+                0xC0
+            };
+            using var stream = new MemoryStream(messages);
+            using var reader = new MessagePackStreamReader(stream);
+            var cancellationToken = CancellationToken.None;
+            // Act: Read a message to cause buffering of data.
+            var _ = await reader.ReadAsync(cancellationToken);
+            Assert.NotEmpty(reader.RemainingBytes.ToArray());
+            // Discard buffered data.
+            reader.DiscardBufferedData();
+            // Assert: The buffered data has been reset.
+            Assert.Empty(reader.RemainingBytes.ToArray());
+        }
+
+        /// <summary>
+        /// Tests that calling Dispose on MessagePackStreamReader disposes the underlying stream when leaveOpen is false.
+        /// </summary>
+        [Fact]
+        public void Dispose_WithLeaveOpenFalse_DisposesUnderlyingStream()
+        {
+            // Arrange
+            var testStream = new TestStream();
+            var reader = new MessagePackStreamReader(testStream, leaveOpen: false);
+            // Act
+            reader.Dispose();
+            // Assert
+            Assert.True(testStream.IsDisposed);
+        }
+
+        /// <summary>
+        /// Tests that calling Dispose on MessagePackStreamReader does not dispose the underlying stream when leaveOpen is true.
+        /// </summary>
+        [Fact]
+        public void Dispose_WithLeaveOpenTrue_DoesNotDisposeUnderlyingStream()
+        {
+            // Arrange
+            var testStream = new TestStream();
+            var reader = new MessagePackStreamReader(testStream, leaveOpen: true);
+            // Act
+            reader.Dispose();
+            // Assert
+            Assert.False(testStream.IsDisposed);
+        }
+
+        /// <summary>
+        /// A helper stream class to track disposal state.
+        /// </summary>
+        private class TestStream : MemoryStream
+        {
+            /// <summary>
+            /// Indicates whether the stream has been disposed.
+            /// </summary>
+            public bool IsDisposed { get; private set; }
+
+            /// <inheritdoc/>
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                IsDisposed = true;
+            }
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MultiplexingStream.ChannelOfferEventArgsTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStream.ChannelOfferEventArgsTests.cs
@@ -1,0 +1,77 @@
+using System;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="MultiplexingStream.ChannelOfferEventArgs"/> class.
+    /// </summary>
+    public class ChannelOfferEventArgsTests
+    {
+        /// <summary>
+        /// Tests the constructor of <see cref="MultiplexingStream.ChannelOfferEventArgs"/>
+        /// to ensure that all properties are initialized correctly with valid parameters.
+        /// </summary>
+//         [Fact] [Error] (23-35)CS7036 There is no argument given that corresponds to the required parameter 'source' of 'QualifiedChannelId.QualifiedChannelId(long, ChannelSource)' [Error] (26-33)CS1729 'MultiplexingStream.ChannelOfferEventArgs' does not contain a constructor that takes 3 arguments [Error] (29-26)CS1503 Argument 1: cannot convert from 'Nerdbank.Streams.UnitTests.QualifiedChannelId' to 'System.DateTime' [Error] (29-39)CS1503 Argument 2: cannot convert from 'Nerdbank.Streams.MultiplexingStream.QualifiedChannelId' to 'System.DateTime'
+//         public void Constructor_ValidParameters_InitializesProperties()
+//         {
+//             // Arrange
+//             var expectedIdValue = 1L;
+//             var expectedName = "TestChannel";
+//             var expectedAccepted = false;
+//             var qualifiedId = new QualifiedChannelId(expectedIdValue);
+// 
+//             // Act
+//             var eventArgs = new MultiplexingStream.ChannelOfferEventArgs(qualifiedId, expectedName, expectedAccepted);
+// 
+//             // Assert
+//             Assert.Equal(qualifiedId, eventArgs.QualifiedId);
+//             Assert.Equal(expectedName, eventArgs.Name);
+//             Assert.Equal(expectedAccepted, eventArgs.IsAccepted);
+//             Assert.Equal((int)expectedIdValue, eventArgs.Id);
+//         }
+
+        /// <summary>
+        /// Tests the constructor of <see cref="MultiplexingStream.ChannelOfferEventArgs"/>
+        /// when the channel name is null. Verifies that the Name property is set to null.
+        /// </summary>
+//         [Fact] [Error] (46-35)CS7036 There is no argument given that corresponds to the required parameter 'source' of 'QualifiedChannelId.QualifiedChannelId(long, ChannelSource)' [Error] (49-33)CS1729 'MultiplexingStream.ChannelOfferEventArgs' does not contain a constructor that takes 3 arguments [Error] (52-26)CS1503 Argument 1: cannot convert from 'Nerdbank.Streams.UnitTests.QualifiedChannelId' to 'System.DateTime' [Error] (52-39)CS1503 Argument 2: cannot convert from 'Nerdbank.Streams.MultiplexingStream.QualifiedChannelId' to 'System.DateTime'
+//         public void Constructor_NullName_InitializesProperties()
+//         {
+//             // Arrange
+//             var expectedIdValue = 2L;
+//             string expectedName = null;
+//             var expectedAccepted = true;
+//             var qualifiedId = new QualifiedChannelId(expectedIdValue);
+// 
+//             // Act
+//             var eventArgs = new MultiplexingStream.ChannelOfferEventArgs(qualifiedId, expectedName, expectedAccepted);
+// 
+//             // Assert
+//             Assert.Equal(qualifiedId, eventArgs.QualifiedId);
+//             Assert.Null(eventArgs.Name);
+//             Assert.Equal(expectedAccepted, eventArgs.IsAccepted);
+//             Assert.Equal((int)expectedIdValue, eventArgs.Id);
+//         }
+
+        /// <summary>
+        /// Tests that the <see cref="MultiplexingStream.ChannelOfferEventArgs.Id"/> property
+        /// throws an <see cref="OverflowException"/> when the underlying QualifiedId.Id value exceeds the range of an Int32.
+        /// </summary>
+//         [Fact] [Error] (67-35)CS7036 There is no argument given that corresponds to the required parameter 'source' of 'QualifiedChannelId.QualifiedChannelId(long, ChannelSource)' [Error] (68-33)CS1729 'MultiplexingStream.ChannelOfferEventArgs' does not contain a constructor that takes 3 arguments
+//         public void Id_ValueExceedsIntRange_ThrowsOverflowException()
+//         {
+//             // Arrange
+//             var overflowId = (long)int.MaxValue + 1;
+//             var qualifiedId = new QualifiedChannelId(overflowId);
+//             var eventArgs = new MultiplexingStream.ChannelOfferEventArgs(qualifiedId, "OverflowChannel", false);
+// 
+//             // Act & Assert
+//             Assert.Throws<OverflowException>(() =>
+//             {
+//                 var id = eventArgs.Id;
+//             });
+//         }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MultiplexingStream.ChannelOptionsTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStream.ChannelOptionsTests.cs
@@ -1,0 +1,208 @@
+using NSubstitute;
+using Nerdbank.Streams;
+using System;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="MultiplexingStream.ChannelOptions"/> class.
+    /// </summary>
+    public class MultiplexingStreamChannelOptionsTests
+    {
+        /// <summary>
+        /// Tests that the constructor initializes all properties to their default values.
+        /// Expected: All properties (TraceSource, ExistingPipe, InputPipeOptions, ChannelReceivingWindowSize) are null.
+        /// </summary>
+        [Fact]
+        public void Constructor_DefaultProperties_AreNull()
+        {
+            // Arrange & Act
+            var options = new MultiplexingStream.ChannelOptions();
+
+            // Assert
+            Assert.Null(options.TraceSource);
+            Assert.Null(options.ExistingPipe);
+            Assert.Null(options.InputPipeOptions);
+            Assert.Null(options.ChannelReceivingWindowSize);
+        }
+
+        /// <summary>
+        /// Tests that the TraceSource property can be set and retrieved correctly.
+        /// Expected: The set TraceSource is returned.
+        /// </summary>
+        [Fact]
+        public void TraceSource_SetAndGet_ReturnsSameInstance()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+            var traceSource = new TraceSource("TestSource");
+
+            // Act
+            options.TraceSource = traceSource;
+
+            // Assert
+            Assert.Equal(traceSource, options.TraceSource);
+        }
+
+        /// <summary>
+        /// Tests that setting the ExistingPipe property to null works as expected.
+        /// Expected: ExistingPipe property remains null.
+        /// </summary>
+        [Fact]
+        public void ExistingPipe_SetToNull_StoresNull()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+
+            // Act
+            options.ExistingPipe = null;
+
+            // Assert
+            Assert.Null(options.ExistingPipe);
+        }
+
+        /// <summary>
+        /// Tests that setting the ExistingPipe property to an invalid pipe (both Input and Output are null) throws an ArgumentException.
+        /// Expected: An ArgumentException with a specific message is thrown.
+        /// </summary>
+        [Fact]
+        public void ExistingPipe_SetToInvalidPipe_ThrowsArgumentException()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+            var invalidPipe = Substitute.For<IDuplexPipe>();
+            // Both Input and Output return null.
+            invalidPipe.Input.Returns((PipeReader)null);
+            invalidPipe.Output.Returns((PipeWriter)null);
+
+            // Act & Assert
+            var exception = Assert.Throws<ArgumentException>(() => options.ExistingPipe = invalidPipe);
+            Assert.Equal("At least a reader or writer must be specified.", exception.Message);
+        }
+
+        /// <summary>
+        /// Tests that setting the ExistingPipe property to a valid non-DuplexPipe instance with only Input non-null wraps the pipe and preserves the Input.
+        /// Expected: The ExistingPipe property returns an instance of DuplexPipe wrapping the provided Input.
+        /// </summary>
+        [Fact]
+        public void ExistingPipe_SetValidPipeWithOnlyInputNonNull_WrapsPipeAndPreservesInput()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+            var dummyInput = Substitute.For<PipeReader>();
+            var dummyPipe = Substitute.For<IDuplexPipe>();
+            dummyPipe.Input.Returns(dummyInput);
+            // Set Output to null (allowed because at least one is non-null).
+            dummyPipe.Output.Returns((PipeWriter)null);
+
+            // Act
+            options.ExistingPipe = dummyPipe;
+            var result = options.ExistingPipe;
+
+            // Assert
+            Assert.NotNull(result);
+            // Verify that the returned instance is a wrapped instance (of type DuplexPipe) and not the same as dummyPipe.
+            Assert.NotEqual(dummyPipe, result);
+            // Using reflection to get the type name since DuplexPipe might be internal.
+            Assert.Equal("DuplexPipe", result.GetType().Name);
+            Assert.Equal(dummyInput, result.Input);
+            Assert.Null(result.Output);
+        }
+
+        /// <summary>
+        /// Tests that setting the ExistingPipe property to a valid non-DuplexPipe instance with only Output non-null wraps the pipe and preserves the Output.
+        /// Expected: The ExistingPipe property returns an instance of DuplexPipe wrapping the provided Output.
+        /// </summary>
+        [Fact]
+        public void ExistingPipe_SetValidPipeWithOnlyOutputNonNull_WrapsPipeAndPreservesOutput()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+            var dummyOutput = Substitute.For<PipeWriter>();
+            var dummyPipe = Substitute.For<IDuplexPipe>();
+            // Set Input to null and Output to non-null.
+            dummyPipe.Input.Returns((PipeReader)null);
+            dummyPipe.Output.Returns(dummyOutput);
+
+            // Act
+            options.ExistingPipe = dummyPipe;
+            var result = options.ExistingPipe;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.NotEqual(dummyPipe, result);
+            Assert.Equal("DuplexPipe", result.GetType().Name);
+            Assert.Null(result.Input);
+            Assert.Equal(dummyOutput, result.Output);
+        }
+
+        /// <summary>
+        /// Tests that setting the ExistingPipe property to an instance of DuplexPipe returns the same instance.
+        /// Expected: The ExistingPipe property returns the same DuplexPipe instance that was provided.
+        /// </summary>
+        [Fact]
+        public void ExistingPipe_SetValidPipeThatIsAlreadyDuplexPipe_ReturnsSameInstance()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+            // Create dummy non-null PipeReader and PipeWriter
+            var dummyInput = Substitute.For<PipeReader>();
+            var dummyOutput = Substitute.For<PipeWriter>();
+
+            // Instantiate DuplexPipe directly. We assume DuplexPipe has a public constructor.
+            var duplexPipe = new DuplexPipe(dummyInput, dummyOutput);
+
+            // Act
+            options.ExistingPipe = duplexPipe;
+            var result = options.ExistingPipe;
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Same(duplexPipe, result);
+        }
+
+        /// <summary>
+        /// Tests that the InputPipeOptions property can be set and retrieved correctly.
+        /// Expected: The set value is returned.
+        /// </summary>
+        [Fact]
+        public void InputPipeOptions_SetAndGet_ReturnsSameValue()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+            // For testing purposes, we simply instantiate a new PipeOptions if possible.
+            // As PipeOptions may require parameters, here we test setting to null and then to a non-null value.
+            Assert.Null(options.InputPipeOptions);
+
+            // Act
+            // Since constructing a real PipeOptions might be non-trivial, we create a simple instance.
+            var pipeOptions = new PipeOptions();
+            options.InputPipeOptions = pipeOptions;
+
+            // Assert
+            Assert.Equal(pipeOptions, options.InputPipeOptions);
+        }
+
+        /// <summary>
+        /// Tests that the ChannelReceivingWindowSize property can be set and retrieved correctly.
+        /// Expected: The set numeric value is returned.
+        /// </summary>
+        [Fact]
+        public void ChannelReceivingWindowSize_SetAndGet_ReturnsSameValue()
+        {
+            // Arrange
+            var options = new MultiplexingStream.ChannelOptions();
+            Assert.Null(options.ChannelReceivingWindowSize);
+
+            // Act
+            long testValue = 1024;
+            options.ChannelReceivingWindowSize = testValue;
+
+            // Assert
+            Assert.Equal(testValue, options.ChannelReceivingWindowSize);
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MultiplexingStream.ChannelTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStream.ChannelTests.cs
@@ -1,0 +1,386 @@
+// using System;
+// using System.Buffers;
+// using System.Diagnostics;
+// using System.IO.Pipelines;
+// using System.Threading;
+// using System.Threading.Tasks;
+// using Nerdbank.Streams;
+// using NSubstitute;
+// using Xunit;
+// 
+// namespace Nerdbank.Streams.UnitTests
+// {
+//     // Minimal implementations required for testing
+// 
+//     internal enum ChannelSource
+//     {
+//         Local,
+//         Remote,
+//         Seeded
+//     }
+// 
+//     /// <summary>
+//     /// Minimal fake implementation for QualifiedChannelId.
+//     /// </summary>
+//     internal class FakeQualifiedChannelId
+//     {
+//         public long Id { get; }
+//         public ChannelSource Source { get; }
+//         public string DebuggerDisplay => $"ID:{Id}";
+// 
+//         public FakeQualifiedChannelId(long id, ChannelSource source)
+//         {
+//             Id = id;
+//             Source = source;
+//         }
+// 
+//         public static implicit operator QualifiedChannelId(FakeQualifiedChannelId fake)
+//         {
+//             return new QualifiedChannelId(fake.Id, fake.Source);
+//         }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal implementation for QualifiedChannelId used by Channel.
+//     /// </summary>
+//     public readonly struct QualifiedChannelId
+//     {
+//         public long Id { get; }
+// //         public ChannelSource Source { get; } [Error] (49-30)CS0053 Inconsistent accessibility: property type 'ChannelSource' is less accessible than property 'QualifiedChannelId.Source'
+//         public string DebuggerDisplay => $"ID:{Id}";
+// 
+//         public QualifiedChannelId(long id, ChannelSource source)
+//         {
+//             Id = id;
+//             Source = source;
+//         }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal fake formatter to support serialization calls.
+//     /// </summary>
+//     internal class FakeFormatter
+//     {
+// //         public ReadOnlySequence<byte> Serialize(MultiplexingStream.Channel.AcceptanceParameters parameters) [Error] (64-76)CS0122 'MultiplexingStream.Channel.AcceptanceParameters' is inaccessible due to its protection level [Error] (66-44)CS0122 'MultiplexingStream.Channel.AcceptanceParameters.RemoteWindowSize' is inaccessible due to its protection level
+// //         {
+// //             byte value = (byte)(parameters.RemoteWindowSize ?? 0);
+// //             return new ReadOnlySequence<byte>(new byte[] { value });
+// //         }
+// 
+//         public ReadOnlySequence<byte> SerializeContentProcessed(long bytes)
+//         {
+//             byte value = (byte)(bytes & 0xFF);
+//             return new ReadOnlySequence<byte>(new byte[] { value });
+//         }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal fake implementation for MultiplexingStream.
+//     /// </summary>
+// //     internal class FakeMultiplexingStream : MultiplexingStream [Error] (89-16)CS1729 'MultiplexingStream' does not contain a constructor that takes 0 arguments [Error] (91-13)CS0122 'MultiplexingStream.protocolMajorVersion' is inaccessible due to its protection level [Error] (92-13)CS0200 Property or indexer 'MultiplexingStream.DefaultChannelReceivingWindowSize' cannot be assigned to -- it is read only [Error] (93-13)CS0122 'MultiplexingStream.DefaultChannelTraceSourceFactory' is inaccessible due to its protection level [Error] (94-13)CS0122 'MultiplexingStream.formatter' is inaccessible due to its protection level
+// //     {
+// //         public int OnChannelDisposedCallCount { get; private set; }
+// //         public int OnChannelWritingCompletedCallCount { get; private set; }
+// //         public FrameHeader LastSentFrameHeader { get; private set; }
+// //         public ReadOnlySequence<byte> LastSentFramePayload { get; private set; }
+// //         public bool SendFrameAsyncCalled { get; private set; }
+// //         public FakeFormatter FakeFormatter { get; } = new FakeFormatter();
+// // 
+// //         public FakeMultiplexingStream()
+// //         {
+// //             protocolMajorVersion = 2;
+// //             DefaultChannelReceivingWindowSize = 1024;
+// //             DefaultChannelTraceSourceFactory = (id, name) => new TraceSource($"{id.DebuggerDisplay}_{name}", SourceLevels.All);
+// //             formatter = FakeFormatter;
+// //         }
+// // 
+// //         public override void SendFrame(FrameHeader header, ReadOnlySequence<byte> payload, CancellationToken cancellationToken) [Error] (97-30)CS0115 'FakeMultiplexingStream.SendFrame(FrameHeader, ReadOnlySequence<byte>, CancellationToken)': no suitable method found to override
+// //         {
+// //             LastSentFrameHeader = header;
+// //             LastSentFramePayload = payload;
+// //         }
+// 
+// //         public override async ValueTask SendFrameAsync(FrameHeader header, ReadOnlySequence<byte> payload, CancellationToken cancellationToken) [Error] (103-41)CS0115 'FakeMultiplexingStream.SendFrameAsync(FrameHeader, ReadOnlySequence<byte>, CancellationToken)': no suitable method found to override
+// //         {
+// //             LastSentFrameHeader = header;
+// //             LastSentFramePayload = payload;
+// //             SendFrameAsyncCalled = true;
+// //             await Task.CompletedTask;
+// //         }
+// 
+// //         public override void OnChannelDisposed(MultiplexingStream.Channel channel, Exception? ex) [Error] (111-30)CS0115 'FakeMultiplexingStream.OnChannelDisposed(MultiplexingStream.Channel, Exception?)': no suitable method found to override
+// //         {
+// //             OnChannelDisposedCallCount++;
+// //         }
+// 
+// //         public override void OnChannelWritingCompleted(MultiplexingStream.Channel channel) [Error] (116-30)CS0115 'FakeMultiplexingStream.OnChannelWritingCompleted(MultiplexingStream.Channel)': no suitable method found to override
+// //         {
+// //             OnChannelWritingCompletedCallCount++;
+// //         }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal fake implementation for IDuplexPipe.
+//     /// </summary>
+//     internal class FakeDuplexPipe : IDuplexPipe
+//     {
+//         public PipeReader Input { get; }
+//         public PipeWriter Output { get; }
+// 
+//         public FakeDuplexPipe()
+//         {
+//             var pipe = new Pipe();
+//             Input = pipe.Reader;
+//             Output = pipe.Writer;
+//         }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal fake implementation for ChannelOptions.
+//     /// </summary>
+//     internal class FakeChannelOptions : ChannelOptions
+//     {
+//         public override TraceSource? TraceSource { get; set; }
+//         public override IDuplexPipe? ExistingPipe { get; set; }
+//         public override long? ChannelReceivingWindowSize { get; set; }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal abstract definition for ChannelOptions required by Channel.
+//     /// </summary>
+//     public abstract class ChannelOptions
+//     {
+//         public abstract TraceSource? TraceSource { get; set; }
+//         public abstract IDuplexPipe? ExistingPipe { get; set; }
+//         public abstract long? ChannelReceivingWindowSize { get; set; }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal fake implementation for FrameHeader.
+//     /// </summary>
+//     public class FrameHeader
+//     {
+//         public ControlCode Code { get; set; }
+//         public QualifiedChannelId ChannelId { get; set; }
+//     }
+// 
+//     /// <summary>
+//     /// Minimal definition for ControlCode.
+//     /// </summary>
+//     public enum ControlCode
+//     {
+//         OfferAccepted,
+//         Content,
+//         ContentProcessed
+//     }
+// 
+//     /// <summary>
+//     /// Unit tests for the <see cref="MultiplexingStream.Channel"/> class.
+//     /// </summary>
+// //     public class MultiplexingStreamChannelTests [Error] (190-62)CS0122 'MultiplexingStream.Channel.OfferParameters' is inaccessible due to its protection level
+// //     {
+// //         private readonly FakeMultiplexingStream fakeStream;
+// //         private readonly FakeQualifiedChannelId fakeChannelId;
+// //         private readonly MultiplexingStream.Channel.OfferParameters offerParameters; [Error] (184-53)CS0122 'MultiplexingStream.Channel.OfferParameters' is inaccessible due to its protection level
+// 
+//         public MultiplexingStreamChannelTests()
+//         {
+//             fakeStream = new FakeMultiplexingStream();
+//             fakeChannelId = new FakeQualifiedChannelId(100, ChannelSource.Local);
+//             offerParameters = new MultiplexingStream.Channel.OfferParameters("TestChannel", 512);
+//         }
+// 
+//         /// <summary>
+//         /// Tests that the QualifiedId and Id properties return the correct identifiers.
+//         /// </summary>
+// //         [Fact] [Error] (200-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments [Error] (207-26)CS1503 Argument 1: cannot convert from 'long' to 'System.DateTime' [Error] (207-44)CS1503 Argument 2: cannot convert from 'ulong' to 'System.DateTime'
+// //         public void QualifiedIdAndId_ValidChannel_ReturnsCorrectIdentifiers()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// // 
+// //             // Act
+// //             var qualifiedId = channel.QualifiedId;
+// //             int id = channel.Id;
+// // 
+// //             // Assert
+// //             Assert.Equal(fakeChannelId.Id, qualifiedId.Id);
+// //             Assert.Equal((int)fakeChannelId.Id, id);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that TryAcceptOffer successfully accepts an offer and completes the Acceptance task.
+//         /// </summary>
+// //         [Fact] [Error] (218-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments [Error] (224-35)CS0122 'MultiplexingStream.Channel.TryAcceptOffer(MultiplexingStream.ChannelOptions)' is inaccessible due to its protection level [Error] (229-55)CS1061 'Task' does not contain a definition for 'Result' and no accessible extension method 'Result' accepting a first argument of type 'Task' could be found (are you missing a using directive or an assembly reference?)
+// //         public void TryAcceptOffer_ValidOptions_ReturnsTrueAndCompletesAcceptanceTask()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// //             var options = Substitute.For<ChannelOptions>();
+// //             options.ChannelReceivingWindowSize.Returns(2048);
+// //             options.TraceSource.Returns(new TraceSource("Test", SourceLevels.All));
+// // 
+// //             // Act
+// //             bool result = channel.TryAcceptOffer(options);
+// // 
+// //             // Assert
+// //             Assert.True(result);
+// //             Assert.True(channel.Acceptance.IsCompleted);
+// //             var acceptanceResult = channel.Acceptance.Result;
+// //             Assert.Equal(2048, acceptanceResult.RemoteWindowSize);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that TryAcceptOffer returns false when called after the offer has already been accepted.
+//         /// </summary>
+// //         [Fact] [Error] (240-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments [Error] (244-40)CS0122 'MultiplexingStream.Channel.TryAcceptOffer(MultiplexingStream.ChannelOptions)' is inaccessible due to its protection level [Error] (247-41)CS0122 'MultiplexingStream.Channel.TryAcceptOffer(MultiplexingStream.ChannelOptions)' is inaccessible due to its protection level
+// //         public void TryAcceptOffer_AlreadyAccepted_ReturnsFalse()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// //             var options = Substitute.For<ChannelOptions>();
+// //             options.ChannelReceivingWindowSize.Returns(2048);
+// //             options.TraceSource.Returns(new TraceSource("Test", SourceLevels.All));
+// //             bool firstResult = channel.TryAcceptOffer(options);
+// // 
+// //             // Act
+// //             bool secondResult = channel.TryAcceptOffer(options);
+// // 
+// //             // Assert
+// //             Assert.True(firstResult);
+// //             Assert.False(secondResult);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that OnAccepted successfully sets the acceptance result and updates the remote window size.
+//         /// </summary>
+// //         [Fact] [Error] (261-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments [Error] (262-67)CS0122 'MultiplexingStream.Channel.AcceptanceParameters' is inaccessible due to its protection level [Error] (265-35)CS0122 'MultiplexingStream.Channel.OnAccepted(MultiplexingStream.Channel.AcceptanceParameters)' is inaccessible due to its protection level [Error] (270-51)CS1061 'Task' does not contain a definition for 'Result' and no accessible extension method 'Result' accepting a first argument of type 'Task' could be found (are you missing a using directive or an assembly reference?)
+// //         public void OnAccepted_ValidParameters_ReturnsTrueAndSetsWindowSize()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// //             var acceptanceParams = new MultiplexingStream.Channel.AcceptanceParameters(4096);
+// // 
+// //             // Act
+// //             bool result = channel.OnAccepted(acceptanceParams);
+// // 
+// //             // Assert
+// //             Assert.True(result);
+// //             Assert.True(channel.Acceptance.IsCompleted);
+// //             Assert.Equal(4096, channel.Acceptance.Result.RemoteWindowSize);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that calling Dispose correctly disposes the channel and completes the Completion task.
+//         /// </summary>
+// //         [Fact] [Error] (280-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments
+// //         public void Dispose_Called_ChannelIsDisposedAndCompletionTaskIsCompleted()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// //             Assert.False(channel.IsDisposed);
+// // 
+// //             // Act
+// //             channel.Dispose();
+// //             Task.Delay(100).Wait();
+// // 
+// //             // Assert
+// //             Assert.True(channel.IsDisposed);
+// //             Assert.True(channel.Completion.IsCompleted);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that accessing Input and Output properties throws NotSupportedException when ExistingPipe is specified.
+//         /// </summary>
+// //         [Fact] [Error] (304-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 4 arguments
+// //         public void InputOutput_WhenExistingPipeSpecified_ThrowsNotSupportedException()
+// //         {
+// //             // Arrange
+// //             var fakeExistingPipe = new FakeDuplexPipe();
+// //             var options = Substitute.For<ChannelOptions>();
+// //             options.ExistingPipe.Returns(fakeExistingPipe);
+// //             options.TraceSource.Returns(new TraceSource("Test", SourceLevels.All));
+// //             options.ChannelReceivingWindowSize.Returns(1024);
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters, options);
+// // 
+// //             // Act & Assert
+// //             Assert.Throws<NotSupportedException>(() => { var _ = channel.Input; });
+// //             Assert.Throws<NotSupportedException>(() => { var _ = channel.Output; });
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that calling OnContentProcessed with valid byte count does not throw an exception.
+//         /// </summary>
+// //         [Fact] [Error] (318-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments [Error] (322-21)CS0122 'MultiplexingStream.Channel.TryAcceptOffer(MultiplexingStream.ChannelOptions)' is inaccessible due to its protection level [Error] (325-60)CS0122 'MultiplexingStream.Channel.OnContentProcessed(long)' is inaccessible due to its protection level
+// //         public void OnContentProcessed_ValidBytes_DoesNotThrow()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// //             var options = Substitute.For<ChannelOptions>();
+// //             options.ChannelReceivingWindowSize.Returns(1024);
+// //             options.TraceSource.Returns(new TraceSource("Test", SourceLevels.All));
+// //             channel.TryAcceptOffer(options);
+// // 
+// //             // Act & Assert
+// //             var exception = Record.Exception(() => channel.OnContentProcessed(100));
+// //             Assert.Null(exception);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that OnChannelTerminatedAsync disposes the channel and sets the IsRemotelyTerminated flag.
+//         /// </summary>
+// //         [Fact] [Error] (336-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments [Error] (337-63)CS0122 'MultiplexingStream.Channel.AcceptanceParameters' is inaccessible due to its protection level [Error] (337-21)CS0122 'MultiplexingStream.Channel.OnAccepted(MultiplexingStream.Channel.AcceptanceParameters)' is inaccessible due to its protection level [Error] (340-27)CS0122 'MultiplexingStream.Channel.OnChannelTerminatedAsync(Exception?)' is inaccessible due to its protection level [Error] (345-33)CS0122 'MultiplexingStream.Channel.IsRemotelyTerminated' is inaccessible due to its protection level
+// //         public async Task OnChannelTerminatedAsync_ValidCall_ChannelTerminates()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// //             channel.OnAccepted(new MultiplexingStream.Channel.AcceptanceParameters(1024));
+// // 
+// //             // Act
+// //             await channel.OnChannelTerminatedAsync(new Exception("Remote termination"));
+// //             await Task.Delay(50);
+// // 
+// //             // Assert
+// //             Assert.True(channel.IsDisposed);
+// //             Assert.True(channel.IsRemotelyTerminated);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that OnContentWritingCompleted triggers writer completion and the channel's Completion task eventually completes.
+//         /// </summary>
+// //         [Fact] [Error] (355-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 3 arguments [Error] (356-63)CS0122 'MultiplexingStream.Channel.AcceptanceParameters' is inaccessible due to its protection level [Error] (356-21)CS0122 'MultiplexingStream.Channel.OnAccepted(MultiplexingStream.Channel.AcceptanceParameters)' is inaccessible due to its protection level [Error] (359-21)CS0122 'MultiplexingStream.Channel.OnContentWritingCompleted()' is inaccessible due to its protection level
+// //         public async Task OnContentWritingCompleted_WriterCompletes_ChannelWriterCompleted()
+// //         {
+// //             // Arrange
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters);
+// //             channel.OnAccepted(new MultiplexingStream.Channel.AcceptanceParameters(1024));
+// // 
+// //             // Act
+// //             channel.OnContentWritingCompleted();
+// //             await Task.Delay(50);
+// // 
+// //             // Assert
+// //             Assert.True(channel.Completion.IsCompleted);
+// //             Assert.True(fakeStream.OnChannelWritingCompletedCallCount > 0);
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that the OptionsApplied task completes after channel options are applied.
+//         /// </summary>
+// //         [Fact] [Error] (377-31)CS1729 'MultiplexingStream.Channel' does not contain a constructor that takes 4 arguments [Error] (380-27)CS0122 'MultiplexingStream.Channel.OptionsApplied' is inaccessible due to its protection level [Error] (383-33)CS0122 'MultiplexingStream.Channel.OptionsApplied' is inaccessible due to its protection level
+// //         public async Task OptionsApplied_ChannelOptionsApplied_TaskCompletes()
+// //         {
+// //             // Arrange
+// //             var options = Substitute.For<ChannelOptions>();
+// //             options.ChannelReceivingWindowSize.Returns(2048);
+// //             options.TraceSource.Returns(new TraceSource("Test", SourceLevels.All));
+// //             var channel = new MultiplexingStream.Channel(fakeStream, fakeChannelId, offerParameters, options);
+// // 
+// //             // Act
+// //             await channel.OptionsApplied;
+// // 
+// //             // Assert
+// //             Assert.True(channel.OptionsApplied.IsCompleted);
+// //         }
+//     }
+// }

--- a/test/Nerdbank.Streams.Tests/MultiplexingStream.FrameHeaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStream.FrameHeaderTests.cs
@@ -1,0 +1,97 @@
+using System;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="MultiplexingStream.FrameHeader"/> struct.
+    /// </summary>
+    public class MultiplexingStream_FrameHeaderTests
+    {
+        /// <summary>
+        /// Tests that the RequiredChannelId property returns the set ChannelId.
+        /// </summary>
+//         [Fact] [Error] (22-49)CS0122 'MultiplexingStream.FrameHeader' is inaccessible due to its protection level [Error] (28-48)CS0122 'MultiplexingStream.FrameHeader.RequiredChannelId' is inaccessible due to its protection level
+//         public void RequiredChannelId_ChannelIdSet_ReturnsChannelId()
+//         {
+//             // Arrange
+//             var expectedId = 42;
+//             var expectedSource = (ChannelSource)1;
+//             var expectedQualifiedChannelId = new QualifiedChannelId(expectedId, expectedSource);
+//             var header = new MultiplexingStream.FrameHeader
+//             {
+//                 ChannelId = expectedQualifiedChannelId
+//             };
+// 
+//             // Act
+//             QualifiedChannelId actual = header.RequiredChannelId;
+// 
+//             // Assert
+//             Assert.Equal(expectedQualifiedChannelId, actual);
+//         }
+
+        /// <summary>
+        /// Tests that the RequiredChannelId property throws a MultiplexingProtocolException when ChannelId is null.
+        /// </summary>
+//         [Fact] [Error] (41-49)CS0122 'MultiplexingStream.FrameHeader' is inaccessible due to its protection level [Error] (49-32)CS0122 'MultiplexingStream.FrameHeader.RequiredChannelId' is inaccessible due to its protection level
+//         public void RequiredChannelId_ChannelIdNull_ThrowsMultiplexingProtocolException()
+//         {
+//             // Arrange
+//             var header = new MultiplexingStream.FrameHeader
+//             {
+//                 ChannelId = null
+//             };
+// 
+//             // Act & Assert
+//             MultiplexingProtocolException exception = Assert.Throws<MultiplexingProtocolException>(() =>
+//             {
+//                 var _ = header.RequiredChannelId;
+//             });
+//             Assert.Equal("Expected ChannelId not present in frame header.", exception.Message);
+//         }
+
+        /// <summary>
+        /// Tests that the FlipChannelPerspective method correctly flips the ChannelSource value when ChannelId is not null.
+        /// </summary>
+//         [Fact] [Error] (64-49)CS0122 'MultiplexingStream.FrameHeader' is inaccessible due to its protection level [Error] (70-20)CS0122 'MultiplexingStream.FrameHeader.FlipChannelPerspective()' is inaccessible due to its protection level [Error] (73-32)CS0122 'MultiplexingStream.FrameHeader.ChannelId' is inaccessible due to its protection level [Error] (74-45)CS0122 'MultiplexingStream.FrameHeader.ChannelId' is inaccessible due to its protection level [Error] (75-73)CS0122 'MultiplexingStream.FrameHeader.ChannelId' is inaccessible due to its protection level
+//         public void FlipChannelPerspective_ChannelIdSet_FlipsChannelSource()
+//         {
+//             // Arrange
+//             int expectedId = 100;
+//             // Set initial source to a positive value (e.g., 3), expecting flipped value to be -3.
+//             var initialSource = (ChannelSource)3;
+//             var header = new MultiplexingStream.FrameHeader
+//             {
+//                 ChannelId = new QualifiedChannelId(expectedId, initialSource)
+//             };
+// 
+//             // Act
+//             header.FlipChannelPerspective();
+// 
+//             // Assert
+//             Assert.True(header.ChannelId.HasValue);
+//             Assert.Equal(expectedId, header.ChannelId.Value.Id);
+//             Assert.Equal((ChannelSource)(-((int)initialSource)), header.ChannelId.Value.Source);
+//         }
+
+        /// <summary>
+        /// Tests that the FlipChannelPerspective method does nothing when ChannelId is null.
+        /// </summary>
+//         [Fact] [Error] (85-49)CS0122 'MultiplexingStream.FrameHeader' is inaccessible due to its protection level [Error] (91-20)CS0122 'MultiplexingStream.FrameHeader.FlipChannelPerspective()' is inaccessible due to its protection level [Error] (94-32)CS0122 'MultiplexingStream.FrameHeader.ChannelId' is inaccessible due to its protection level
+//         public void FlipChannelPerspective_ChannelIdNull_DoesNothing()
+//         {
+//             // Arrange
+//             var header = new MultiplexingStream.FrameHeader
+//             {
+//                 ChannelId = null
+//             };
+// 
+//             // Act
+//             header.FlipChannelPerspective();
+// 
+//             // Assert
+//             Assert.Null(header.ChannelId);
+//         }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MultiplexingStream.OptionsTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStream.OptionsTests.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using Nerdbank.Streams;
+using NSubstitute;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="MultiplexingStream.Options"/> class.
+    /// </summary>
+    public class MultiplexingStreamOptionsTests
+    {
+        private readonly TraceSource _defaultTraceSource;
+
+        public MultiplexingStreamOptionsTests()
+        {
+            _defaultTraceSource = new TraceSource(nameof(MultiplexingStream), SourceLevels.Critical);
+        }
+
+        /// <summary>
+        /// Tests that the default constructor initializes SeededChannels to an empty modifiable list.
+        /// </summary>
+        [Fact]
+        public void Constructor_Default_SeededChannelsIsNotNullAndEmpty()
+        {
+            // Arrange & Act
+            var options = new MultiplexingStream.Options();
+
+            // Assert
+            Assert.NotNull(options.SeededChannels);
+            Assert.Empty(options.SeededChannels);
+        }
+
+        /// <summary>
+        /// Tests that the copy constructor throws an exception when provided with a null parameter.
+        /// </summary>
+        [Fact]
+        public void Constructor_CopyConstructor_NullParameter_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new MultiplexingStream.Options(null));
+        }
+
+        /// <summary>
+        /// Tests that the copy constructor correctly copies all properties from the source instance.
+        /// </summary>
+//         [Fact] [Error] (66-70)CS0029 Cannot implicitly convert type 'System.Func<Nerdbank.Streams.UnitTests.QualifiedChannelId, string, System.Diagnostics.TraceSource?>' to 'System.Func<Nerdbank.Streams.MultiplexingStream.QualifiedChannelId, string, System.Diagnostics.TraceSource?>' [Error] (69-41)CS1503 Argument 1: cannot convert from 'Nerdbank.Streams.UnitTests.ChannelOptions' to 'Nerdbank.Streams.MultiplexingStream.ChannelOptions'
+//         public void Constructor_CopyConstructor_ValidCopy_CopiesAllProperties()
+//         {
+//             // Arrange
+//             var original = new MultiplexingStream.Options();
+//             original.ProtocolMajorVersion = 2;
+//             original.DefaultChannelReceivingWindowSize = 100;
+//             var originalTrace = new TraceSource("Original", SourceLevels.Information);
+//             original.TraceSource = originalTrace;
+//             original.StartSuspended = true;
+//             original.FaultOpenChannelsOnStreamDisposal = true;
+//             // Assign dummy delegates.
+//             Func<int, string, TraceSource?> dummyFactory = (id, name) => new TraceSource(name);
+//             original.DefaultChannelTraceSourceFactory = dummyFactory;
+//             Func<QualifiedChannelId, string, TraceSource?> dummyFactoryWithQualifier = (qc, name) => new TraceSource(name);
+//             original.DefaultChannelTraceSourceFactoryWithQualifier = dummyFactoryWithQualifier;
+//             // Add a dummy seeded channel using NSubstitute.
+//             var dummyChannelOptions = Substitute.For<ChannelOptions>();
+//             original.SeededChannels.Add(dummyChannelOptions);
+// 
+//             // Act
+//             var copy = new MultiplexingStream.Options(original);
+// 
+//             // Assert
+//             Assert.Equal(original.ProtocolMajorVersion, copy.ProtocolMajorVersion);
+//             Assert.Equal(original.DefaultChannelReceivingWindowSize, copy.DefaultChannelReceivingWindowSize);
+//             Assert.Equal(original.TraceSource, copy.TraceSource);
+//             Assert.Equal(original.StartSuspended, copy.StartSuspended);
+//             Assert.Equal(original.FaultOpenChannelsOnStreamDisposal, copy.FaultOpenChannelsOnStreamDisposal);
+//             Assert.Equal(original.DefaultChannelTraceSourceFactory, copy.DefaultChannelTraceSourceFactory);
+//             Assert.Equal(original.DefaultChannelTraceSourceFactoryWithQualifier, copy.DefaultChannelTraceSourceFactoryWithQualifier);
+//             Assert.Equal(original.SeededChannels.Count, copy.SeededChannels.Count);
+//             // Ensure deep copy for SeededChannels: modifying the original list does not affect the copy.
+//             original.SeededChannels.Clear();
+//             Assert.NotEqual(original.SeededChannels.Count, copy.SeededChannels.Count);
+//         }
+
+        /// <summary>
+        /// Tests that setting a valid DefaultChannelReceivingWindowSize succeeds.
+        /// </summary>
+        [Fact]
+        public void DefaultChannelReceivingWindowSize_SetValidValue_Succeeds()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            long validValue = 200;
+
+            // Act
+            options.DefaultChannelReceivingWindowSize = validValue;
+
+            // Assert
+            Assert.Equal(validValue, options.DefaultChannelReceivingWindowSize);
+        }
+
+        /// <summary>
+        /// Tests that setting an invalid DefaultChannelReceivingWindowSize (zero or negative) throws an exception.
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-10)]
+        public void DefaultChannelReceivingWindowSize_SetInvalidValue_ThrowsArgumentOutOfRangeException(long invalidValue)
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(() => options.DefaultChannelReceivingWindowSize = invalidValue);
+        }
+
+        /// <summary>
+        /// Tests that setting a valid ProtocolMajorVersion succeeds.
+        /// </summary>
+        [Fact]
+        public void ProtocolMajorVersion_SetValidValue_Succeeds()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            int validVersion = 3;
+
+            // Act
+            options.ProtocolMajorVersion = validVersion;
+
+            // Assert
+            Assert.Equal(validVersion, options.ProtocolMajorVersion);
+        }
+
+        /// <summary>
+        /// Tests that setting an invalid ProtocolMajorVersion (zero or negative) throws an exception.
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ProtocolMajorVersion_SetInvalidValue_ThrowsArgumentOutOfRangeException(int invalidVersion)
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(() => options.ProtocolMajorVersion = invalidVersion);
+        }
+
+        /// <summary>
+        /// Tests that setting a valid TraceSource succeeds.
+        /// </summary>
+        [Fact]
+        public void TraceSource_SetValidValue_Succeeds()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            var newTraceSource = new TraceSource("TestTraceSource", SourceLevels.Warning);
+
+            // Act
+            options.TraceSource = newTraceSource;
+
+            // Assert
+            Assert.Equal(newTraceSource, options.TraceSource);
+        }
+
+        /// <summary>
+        /// Tests that setting TraceSource to null throws an exception.
+        /// </summary>
+        [Fact]
+        public void TraceSource_SetNullValue_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => options.TraceSource = null);
+        }
+
+        /// <summary>
+        /// Tests that setting a valid DefaultChannelTraceSourceFactory delegate succeeds.
+        /// </summary>
+        [Fact]
+        public void DefaultChannelTraceSourceFactory_SetValidValue_Succeeds()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            Func<int, string, TraceSource?> factory = (id, name) => new TraceSource(name);
+
+            // Act
+            options.DefaultChannelTraceSourceFactory = factory;
+
+            // Assert
+            Assert.Equal(factory, options.DefaultChannelTraceSourceFactory);
+        }
+
+        /// <summary>
+        /// Tests that setting a valid DefaultChannelTraceSourceFactoryWithQualifier delegate succeeds.
+        /// </summary>
+//         [Fact] [Error] (210-69)CS0029 Cannot implicitly convert type 'System.Func<Nerdbank.Streams.UnitTests.QualifiedChannelId, string, System.Diagnostics.TraceSource?>' to 'System.Func<Nerdbank.Streams.MultiplexingStream.QualifiedChannelId, string, System.Diagnostics.TraceSource?>' [Error] (213-26)CS1503 Argument 1: cannot convert from 'System.Func<Nerdbank.Streams.UnitTests.QualifiedChannelId, string, System.Diagnostics.TraceSource?>' to 'System.DateTime' [Error] (213-48)CS1503 Argument 2: cannot convert from 'System.Func<Nerdbank.Streams.MultiplexingStream.QualifiedChannelId, string, System.Diagnostics.TraceSource?>' to 'System.DateTime'
+//         public void DefaultChannelTraceSourceFactoryWithQualifier_SetValidValue_Succeeds()
+//         {
+//             // Arrange
+//             var options = new MultiplexingStream.Options();
+//             Func<QualifiedChannelId, string, TraceSource?> factoryWithQualifier = (qc, name) => new TraceSource(name);
+// 
+//             // Act
+//             options.DefaultChannelTraceSourceFactoryWithQualifier = factoryWithQualifier;
+// 
+//             // Assert
+//             Assert.Equal(factoryWithQualifier, options.DefaultChannelTraceSourceFactoryWithQualifier);
+//         }
+
+        /// <summary>
+        /// Tests that setting the StartSuspended property succeeds.
+        /// </summary>
+        [Fact]
+        public void StartSuspended_SetValidValue_Succeeds()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            bool newValue = true;
+
+            // Act
+            options.StartSuspended = newValue;
+
+            // Assert
+            Assert.Equal(newValue, options.StartSuspended);
+        }
+
+        /// <summary>
+        /// Tests that setting the FaultOpenChannelsOnStreamDisposal property succeeds.
+        /// </summary>
+        [Fact]
+        public void FaultOpenChannelsOnStreamDisposal_SetValidValue_Succeeds()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            bool newValue = true;
+
+            // Act
+            options.FaultOpenChannelsOnStreamDisposal = newValue;
+
+            // Assert
+            Assert.Equal(newValue, options.FaultOpenChannelsOnStreamDisposal);
+        }
+
+        /// <summary>
+        /// Tests that GetFrozenCopy returns a frozen copy of the instance and makes SeededChannels read-only.
+        /// </summary>
+        [Fact]
+        public void GetFrozenCopy_NotFrozenInstance_ReturnsFrozenCopy()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            options.ProtocolMajorVersion = 2;
+            options.DefaultChannelReceivingWindowSize = 150;
+            options.StartSuspended = true;
+            options.FaultOpenChannelsOnStreamDisposal = true;
+
+            // Act
+            var frozenCopy = options.GetFrozenCopy();
+
+            // Assert
+            Assert.True(frozenCopy.IsFrozen);
+            Assert.Equal(options.ProtocolMajorVersion, frozenCopy.ProtocolMajorVersion);
+            Assert.Equal(options.DefaultChannelReceivingWindowSize, frozenCopy.DefaultChannelReceivingWindowSize);
+            Assert.Equal(options.StartSuspended, frozenCopy.StartSuspended);
+            Assert.Equal(options.FaultOpenChannelsOnStreamDisposal, frozenCopy.FaultOpenChannelsOnStreamDisposal);
+            // SeededChannels should be a ReadOnlyCollection in the frozen copy.
+            Assert.IsType<ReadOnlyCollection<ChannelOptions>>(frozenCopy.SeededChannels);
+        }
+
+        /// <summary>
+        /// Tests that calling GetFrozenCopy on an already frozen instance returns the same instance.
+        /// </summary>
+        [Fact]
+        public void GetFrozenCopy_AlreadyFrozen_ReturnsSameInstance()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            var frozenCopy = options.GetFrozenCopy();
+
+            // Act
+            var result = frozenCopy.GetFrozenCopy();
+
+            // Assert
+            Assert.Same(frozenCopy, result);
+        }
+
+        /// <summary>
+        /// Tests that modifying a frozen instance throws an exception.
+        /// </summary>
+        [Fact]
+        public void FrozenInstance_Modification_ThrowsException()
+        {
+            // Arrange
+            var options = new MultiplexingStream.Options();
+            var frozenOptions = options.GetFrozenCopy();
+
+            // Act & Assert
+            Assert.Throws<Exception>(() => frozenOptions.DefaultChannelReceivingWindowSize = 300);
+            Assert.Throws<Exception>(() => frozenOptions.ProtocolMajorVersion = 4);
+            Assert.Throws<Exception>(() => frozenOptions.TraceSource = new TraceSource("NewSource"));
+            Assert.Throws<Exception>(() => frozenOptions.DefaultChannelTraceSourceFactory = (id, name) => new TraceSource(name));
+            Assert.Throws<Exception>(() => frozenOptions.DefaultChannelTraceSourceFactoryWithQualifier = (qc, name) => new TraceSource(name));
+            Assert.Throws<Exception>(() => frozenOptions.StartSuspended = true);
+            Assert.Throws<Exception>(() => frozenOptions.FaultOpenChannelsOnStreamDisposal = true);
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/MultiplexingStream.OptionsTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStream.OptionsTests.cs
@@ -270,7 +270,7 @@ namespace Nerdbank.Streams.UnitTests
             Assert.Equal(options.StartSuspended, frozenCopy.StartSuspended);
             Assert.Equal(options.FaultOpenChannelsOnStreamDisposal, frozenCopy.FaultOpenChannelsOnStreamDisposal);
             // SeededChannels should be a ReadOnlyCollection in the frozen copy.
-            Assert.IsType<ReadOnlyCollection<ChannelOptions>>(frozenCopy.SeededChannels);
+            Assert.IsType<ReadOnlyCollection<MultiplexingStream.ChannelOptions>>(frozenCopy.SeededChannels);
         }
 
         /// <summary>

--- a/test/Nerdbank.Streams.Tests/MultiplexingStream.QualifiedChannelIdTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStream.QualifiedChannelIdTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.Reflection;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="MultiplexingStream.QualifiedChannelId"/> struct.
+    /// </summary>
+    public class QualifiedChannelIdTests
+    {
+        private readonly ulong _sampleId;
+        private readonly MultiplexingStream.ChannelSource _localSource;
+        private readonly MultiplexingStream.ChannelSource _remoteSource;
+        private readonly MultiplexingStream.ChannelSource _seededSource;
+
+        public QualifiedChannelIdTests()
+        {
+            _sampleId = 123456789;
+            _localSource = MultiplexingStream.ChannelSource.Local;
+            _remoteSource = MultiplexingStream.ChannelSource.Remote;
+            _seededSource = MultiplexingStream.ChannelSource.Seeded;
+        }
+
+        /// <summary>
+        /// Tests that the constructor initializes the properties correctly.
+        /// Arrange: Provide a sample id and channel source.
+        /// Act: Instantiate a QualifiedChannelId.
+        /// Assert: Verify that the Id and Source properties have been set accordingly.
+        /// </summary>
+        [Fact]
+        public void Constructor_ShouldInitializeProperties()
+        {
+            // Act
+            var qualifiedId = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+
+            // Assert
+            Assert.Equal(_sampleId, qualifiedId.Id);
+            Assert.Equal(_localSource, qualifiedId.Source);
+        }
+
+        /// <summary>
+        /// Tests the Equals method for two QualifiedChannelId instances with identical values.
+        /// Arrange: Create two instances with the same id and source.
+        /// Act: Compare using the Equals(QualifiedChannelId) method.
+        /// Assert: The method should return true.
+        /// </summary>
+        [Fact]
+        public void Equals_WithSameValues_ReturnsTrue()
+        {
+            // Arrange
+            var qualifiedId1 = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+            var qualifiedId2 = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+
+            // Act
+            bool result = qualifiedId1.Equals(qualifiedId2);
+
+            // Assert
+            Assert.True(result, "Expected two QualifiedChannelId instances with identical values to be equal.");
+        }
+
+        /// <summary>
+        /// Tests the Equals method for two QualifiedChannelId instances with different ids.
+        /// Arrange: Create two instances with different ids.
+        /// Act: Compare using the Equals(QualifiedChannelId) method.
+        /// Assert: The method should return false.
+        /// </summary>
+        [Fact]
+        public void Equals_WithDifferentId_ReturnsFalse()
+        {
+            // Arrange
+            var qualifiedId1 = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+            var qualifiedId2 = new MultiplexingStream.QualifiedChannelId(_sampleId + 1, _localSource);
+
+            // Act
+            bool result = qualifiedId1.Equals(qualifiedId2);
+
+            // Assert
+            Assert.False(result, "Expected QualifiedChannelId instances with different ids to not be equal.");
+        }
+
+        /// <summary>
+        /// Tests the Equals method for two QualifiedChannelId instances with different sources.
+        /// Arrange: Create two instances with the same id but different sources.
+        /// Act: Compare using the Equals(QualifiedChannelId) method.
+        /// Assert: The method should return false.
+        /// </summary>
+        [Fact]
+        public void Equals_WithDifferentSource_ReturnsFalse()
+        {
+            // Arrange
+            var qualifiedId1 = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+            var qualifiedId2 = new MultiplexingStream.QualifiedChannelId(_sampleId, _remoteSource);
+
+            // Act
+            bool result = qualifiedId1.Equals(qualifiedId2);
+
+            // Assert
+            Assert.False(result, "Expected QualifiedChannelId instances with different sources to not be equal.");
+        }
+
+        /// <summary>
+        /// Tests the overridden Equals(object) method using an object of type QualifiedChannelId with identical values.
+        /// Arrange: Create an instance and box an identical instance.
+        /// Act: Compare using the Equals(object) method.
+        /// Assert: The method should return true.
+        /// </summary>
+        [Fact]
+        public void Equals_Object_WithSameValues_ReturnsTrue()
+        {
+            // Arrange
+            var qualifiedId = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+            object equivalentObject = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+
+            // Act
+            bool result = qualifiedId.Equals(equivalentObject);
+
+            // Assert
+            Assert.True(result, "Expected Equals(object) to return true for an equivalent QualifiedChannelId instance.");
+        }
+
+        /// <summary>
+        /// Tests the overridden Equals(object) method when comparing with an object of a different type.
+        /// Arrange: Create an instance and an object of a different type.
+        /// Act: Compare using the Equals(object) method.
+        /// Assert: The method should return false.
+        /// </summary>
+        [Fact]
+        public void Equals_Object_WithDifferentType_ReturnsFalse()
+        {
+            // Arrange
+            var qualifiedId = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+            object nonQualifiedId = "Invalid Type";
+
+            // Act
+            bool result = qualifiedId.Equals(nonQualifiedId);
+
+            // Assert
+            Assert.False(result, "Expected Equals(object) to return false when comparing with an object of a different type.");
+        }
+
+        /// <summary>
+        /// Tests that two equal QualifiedChannelId instances return the same hash code.
+        /// Arrange: Create two instances with identical values.
+        /// Act: Retrieve their hash codes.
+        /// Assert: Both hash codes should be equal.
+        /// </summary>
+        [Fact]
+        public void GetHashCode_EqualObjects_SameHashCode()
+        {
+            // Arrange
+            var qualifiedId1 = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+            var qualifiedId2 = new MultiplexingStream.QualifiedChannelId(_sampleId, _localSource);
+
+            // Act
+            int hash1 = qualifiedId1.GetHashCode();
+            int hash2 = qualifiedId2.GetHashCode();
+
+            // Assert
+            Assert.Equal(hash1, hash2);
+        }
+
+        /// <summary>
+        /// Tests the ToString method to ensure it returns the expected string format.
+        /// Arrange: Create an instance with a known id and source.
+        /// Act: Call the ToString method.
+        /// Assert: The returned string matches the "id (source)" format.
+        /// </summary>
+        [Fact]
+        public void ToString_ReturnsCorrectFormat()
+        {
+            // Arrange
+            ulong id = 100;
+            var source = _remoteSource;
+            var qualifiedId = new MultiplexingStream.QualifiedChannelId(id, source);
+            string expectedFormat = $"{id} ({source})";
+
+            // Act
+            string result = qualifiedId.ToString();
+
+            // Assert
+            Assert.Equal(expectedFormat, result);
+        }
+
+        /// <summary>
+        /// Tests that the internal DebuggerDisplay property returns the same string as the ToString method.
+        /// Arrange: Create an instance with known values.
+        /// Act: Retrieve the DebuggerDisplay value using reflection.
+        /// Assert: The DebuggerDisplay value matches the output of ToString.
+        /// </summary>
+        [Fact]
+        public void DebuggerDisplay_ReturnsSameAsToString()
+        {
+            // Arrange
+            var qualifiedId = new MultiplexingStream.QualifiedChannelId(200, _seededSource);
+            string expected = qualifiedId.ToString();
+
+            // Act
+            PropertyInfo debuggerDisplayProperty = typeof(MultiplexingStream.QualifiedChannelId)
+                .GetProperty("DebuggerDisplay", BindingFlags.NonPublic | BindingFlags.Instance);
+            string actual = debuggerDisplayProperty?.GetValue(qualifiedId)?.ToString();
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
+++ b/test/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>
+    <!--<TargetFrameworks Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(TargetFrameworks);net472</TargetFrameworks>-->
     <OutputType>Exe</OutputType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <RootNamespace />

--- a/test/Nerdbank.Streams.Tests/NilTests.cs
+++ b/test/Nerdbank.Streams.Tests/NilTests.cs
@@ -1,0 +1,112 @@
+using System;
+using MessagePack;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="Nil"/> struct.
+    /// </summary>
+    public class NilTests
+    {
+        private readonly Nil _nilInstance;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NilTests"/> class.
+        /// </summary>
+        public NilTests()
+        {
+            _nilInstance = Nil.Default;
+        }
+
+        /// <summary>
+        /// Tests that the Equals(object) method returns true when passed an instance of Nil.
+        /// </summary>
+        [Fact]
+        public void Equals_Object_WithNilInstance_ReturnsTrue()
+        {
+            // Arrange
+            object otherNil = new Nil();
+
+            // Act
+            bool result = _nilInstance.Equals(otherNil);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        /// <summary>
+        /// Tests that the Equals(object) method returns false when passed an object of a different type.
+        /// </summary>
+        [Fact]
+        public void Equals_Object_WithDifferentType_ReturnsFalse()
+        {
+            // Arrange
+            object nonNilObject = new object();
+
+            // Act
+            bool result = _nilInstance.Equals(nonNilObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        /// <summary>
+        /// Tests that the Equals(object) method returns false when passed a null value.
+        /// </summary>
+        [Fact]
+        public void Equals_Object_WithNull_ReturnsFalse()
+        {
+            // Arrange
+            object nullObject = null;
+
+            // Act
+            bool result = _nilInstance.Equals(nullObject);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        /// <summary>
+        /// Tests that the Equals(Nil) method always returns true irrespective of the instance values.
+        /// </summary>
+        [Fact]
+        public void Equals_Nil_AlwaysReturnsTrue()
+        {
+            // Arrange
+            Nil otherNil = new Nil();
+
+            // Act
+            bool result = _nilInstance.Equals(otherNil);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        /// <summary>
+        /// Tests that the GetHashCode method always returns 0.
+        /// </summary>
+        [Fact]
+        public void GetHashCode_AlwaysReturnsZero()
+        {
+            // Act
+            int hashCode = _nilInstance.GetHashCode();
+
+            // Assert
+            Assert.Equal(0, hashCode);
+        }
+
+        /// <summary>
+        /// Tests that the ToString method returns the string representation "()".
+        /// </summary>
+        [Fact]
+        public void ToString_ReturnsParentheses()
+        {
+            // Act
+            string result = _nilInstance.ToString();
+
+            // Assert
+            Assert.Equal("()", result);
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/SequencePoolTests.cs
+++ b/test/Nerdbank.Streams.Tests/SequencePoolTests.cs
@@ -1,0 +1,105 @@
+using MessagePack;
+using Nerdbank.Streams;
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref = "SequencePool"/> class.
+    /// </summary>
+    public class SequencePoolTests
+    {
+        private const int MinimumSpanLengthConstant = 32 * 1024;
+        /// <summary>
+        /// Tests that Rent returns a non-null Rental with a non-null Sequence value and the expected MinimumSpanLength.
+        /// </summary>
+//         [Fact] [Error] (24-31)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?)
+//         public void Rent_WhenCalled_ReturnsValidRentalWithExpectedMinimumSpanLength()
+//         {
+//             // Arrange
+//             var pool = new SequencePool(10);
+//             // Act
+//             var rental = pool.Rent();
+//             // Assert
+//             Assert.NotNull(rental);
+//             Assert.NotNull(rental.Value);
+//             Assert.Equal(MinimumSpanLengthConstant, rental.Value.MinimumSpanLength);
+//         }
+
+        /// <summary>
+        /// Tests that upon disposing a Rental, the Sequence is returned to the pool and later reused.
+        /// </summary>
+//         [Fact] [Error] (40-32)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?) [Error] (43-32)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?)
+//         public void Dispose_AfterRent_ReturnsSequenceToPoolForReuse()
+//         {
+//             // Arrange
+//             var pool = new SequencePool(1);
+//             // Act
+//             var rental1 = pool.Rent();
+//             Sequence<byte> firstInstance = rental1.Value;
+//             rental1.Dispose();
+//             var rental2 = pool.Rent();
+//             Sequence<byte> secondInstance = rental2.Value;
+//             // Assert
+//             Assert.Same(firstInstance, secondInstance);
+//         }
+
+        /// <summary>
+        /// Tests that disposing a Rental twice does not result in duplicate entries in the pool.
+        /// </summary>
+//         [Fact] [Error] (58-31)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?) [Error] (63-36)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?) [Error] (68-34)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?)
+//         public void Dispose_CalledTwice_DoesNotDuplicateSequenceInPool()
+//         {
+//             // Arrange
+//             var pool = new SequencePool(1);
+//             // Act
+//             var rental = pool.Rent();
+//             Sequence<byte> instance = rental.Value;
+//             rental.Dispose();
+//             // Second disposal call should not add the sequence again because pool is at capacity.
+//             rental.Dispose();
+//             var rentalAfter = pool.Rent();
+//             Sequence<byte> reusedInstance = rentalAfter.Value;
+//             // Assert
+//             Assert.Same(instance, reusedInstance);
+//             // Renting again should create a new instance.
+//             var rentalNew = pool.Rent();
+//             Assert.NotSame(reusedInstance, rentalNew.Value);
+//         }
+
+        /// <summary>
+        /// Tests that the MinimumSpanLength on a Sequence is reset to the preferred constant after disposal even if modified.
+        /// </summary>
+//         [Fact] [Error] (80-31)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?) [Error] (84-36)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?)
+//         public void Dispose_AfterModifyingMinimumSpanLength_ResetsToPreferredValue()
+//         {
+//             // Arrange
+//             var pool = new SequencePool(1);
+//             var rental = pool.Rent();
+//             // Act
+//             rental.Value.MinimumSpanLength = 1024;
+//             rental.Dispose();
+//             var rentedAgain = pool.Rent();
+//             // Assert
+//             Assert.Equal(MinimumSpanLengthConstant, rentedAgain.Value.MinimumSpanLength);
+//         }
+
+        /// <summary>
+        /// Tests that Rent creates a new Sequence when the pool is empty.
+        /// </summary>
+//         [Fact] [Error] (98-32)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?) [Error] (100-32)CS1061 'SequencePool' does not contain a definition for 'Rent' and no accessible extension method 'Rent' accepting a first argument of type 'SequencePool' could be found (are you missing a using directive or an assembly reference?)
+//         public void Rent_WhenPoolIsEmpty_ReturnsNewSequenceInstance()
+//         {
+//             // Arrange
+//             var pool = new SequencePool(1);
+//             // Act
+//             var rental1 = pool.Rent();
+//             // Do not dispose rental1, so pool is empty.
+//             var rental2 = pool.Rent();
+//             // Assert
+//             Assert.NotSame(rental1.Value, rental2.Value);
+//         }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/Sequence`1Tests.cs
+++ b/test/Nerdbank.Streams.Tests/Sequence`1Tests.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Buffers;
+using Nerdbank.Streams;
+using NSubstitute;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="Sequence{T}"/> class.
+    /// </summary>
+    public class SequenceTests
+    {
+        private readonly ArrayPool<byte> arrayPool;
+        private readonly MemoryPool<byte> memoryPool;
+
+        public SequenceTests()
+        {
+            arrayPool = ArrayPool<byte>.Shared;
+            memoryPool = MemoryPool<byte>.Shared;
+        }
+
+        /// <summary>
+        /// Tests that the default constructor creates an empty sequence.
+        /// </summary>
+        [Fact]
+        public void Constructor_Default_CreatesEmptySequence()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>();
+
+            // Act
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(0, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that the constructor with a MemoryPool creates an empty sequence.
+        /// </summary>
+        [Fact]
+        public void Constructor_WithMemoryPool_CreatesEmptySequence()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(memoryPool);
+
+            // Act
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(0, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that the constructor with an ArrayPool creates an empty sequence.
+        /// </summary>
+        [Fact]
+        public void Constructor_WithArrayPool_CreatesEmptySequence()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+
+            // Act
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(0, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that GetMemory returns a memory buffer with at least the requested size.
+        /// </summary>
+        [Fact]
+        public void GetMemory_WithPositiveSizeHint_ReturnsMemoryWithSufficientCapacity()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            int requestedSize = 10;
+
+            // Act
+            Memory<byte> memory = sequence.GetMemory(requestedSize);
+
+            // Assert
+            Assert.True(memory.Length >= requestedSize, $"Memory length {memory.Length} is less than requested {requestedSize}.");
+        }
+
+        /// <summary>
+        /// Tests that GetSpan returns a span with at least the requested size.
+        /// </summary>
+        [Fact]
+        public void GetSpan_WithPositiveSizeHint_ReturnsSpanWithSufficientCapacity()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            int requestedSize = 15;
+
+            // Act
+            Span<byte> span = sequence.GetSpan(requestedSize);
+
+            // Assert
+            Assert.True(span.Length >= requestedSize, $"Span length {span.Length} is less than requested {requestedSize}.");
+        }
+
+        /// <summary>
+        /// Tests that calling Advance without acquiring memory throws an InvalidOperationException.
+        /// </summary>
+        [Fact]
+        public void Advance_WithoutAcquiringMemory_ThrowsException()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() => sequence.Advance(5));
+            Assert.Contains("Cannot advance before acquiring memory", ex.Message);
+        }
+
+        /// <summary>
+        /// Tests that Advance correctly commits bytes after acquiring memory.
+        /// </summary>
+        [Fact]
+        public void Advance_AfterGetMemory_CommitsDataAndIncreasesLength()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            int requestedSize = 20;
+            Memory<byte> memory = sequence.GetMemory(requestedSize);
+            int bytesToWrite = 10;
+            // Simulate writing data.
+            memory.Span.Slice(0, bytesToWrite).Fill(0x1);
+
+            // Act
+            sequence.Advance(bytesToWrite);
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(bytesToWrite, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that Append appends non-empty memory to the sequence.
+        /// </summary>
+        [Fact]
+        public void Append_NonEmptyMemory_AppendsData()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            byte[] data = new byte[] { 1, 2, 3, 4 };
+            ReadOnlyMemory<byte> readOnlyMemory = new ReadOnlyMemory<byte>(data);
+
+            // Act
+            sequence.Append(readOnlyMemory);
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(data.Length, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that Append with an empty memory does not alter the sequence.
+        /// </summary>
+        [Fact]
+        public void Append_EmptyMemory_DoesNotChangeSequence()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            byte[] data = Array.Empty<byte>();
+            ReadOnlyMemory<byte> readOnlyMemory = new ReadOnlyMemory<byte>(data);
+
+            // Act
+            sequence.Append(readOnlyMemory);
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(0, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that Reset clears the sequence and resets its length.
+        /// </summary>
+        [Fact]
+        public void Reset_AfterAppendingData_ClearsSequence()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            byte[] data = new byte[] { 5, 6, 7 };
+            sequence.Append(new ReadOnlyMemory<byte>(data));
+            Assert.NotEqual(0, sequence.AsReadOnlySequence.Length);
+
+            // Act
+            sequence.Reset();
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(0, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that Dispose clears the sequence by internally calling Reset.
+        /// </summary>
+        [Fact]
+        public void Dispose_ClearsSequence()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            byte[] data = new byte[] { 9, 8, 7 };
+            sequence.Append(new ReadOnlyMemory<byte>(data));
+            Assert.NotEqual(0, sequence.AsReadOnlySequence.Length);
+
+            // Act
+            sequence.Dispose();
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(0, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that the implicit operator returns an empty ReadOnlySequence when the sequence is null.
+        /// </summary>
+        [Fact]
+        public void ImplicitOperator_NullSequence_ReturnsEmptyReadOnlySequence()
+        {
+            // Arrange
+            Sequence<byte>? sequence = null;
+
+            // Act
+            ReadOnlySequence<byte> roSequence = sequence;
+
+            // Assert
+            Assert.Equal(0, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that AdvanceTo with a default SequencePosition does nothing.
+        /// </summary>
+        [Fact]
+        public void AdvanceTo_DefaultSequencePosition_DoesNothing()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            Memory<byte> memory = sequence.GetMemory(30);
+            int bytesToWrite = 15;
+            memory.Span.Slice(0, bytesToWrite).Fill(0xFF);
+            sequence.Advance(bytesToWrite);
+            ReadOnlySequence<byte> originalSequence = sequence.AsReadOnlySequence;
+
+            // Act
+            sequence.AdvanceTo(default);
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert
+            Assert.Equal(originalSequence.Length, roSequence.Length);
+        }
+
+        /// <summary>
+        /// Tests that AdvanceTo with a valid SequencePosition removes the data before that position.
+        /// </summary>
+        [Fact]
+        public void AdvanceTo_ValidSequencePosition_RemovesDataBeforePosition()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool);
+            Memory<byte> memory = sequence.GetMemory(50);
+            int totalBytes = 20;
+            // Fill memory with sequential data.
+            for (int i = 0; i < totalBytes; i++)
+            {
+                memory.Span[i] = (byte)(i + 1);
+            }
+            sequence.Advance(totalBytes);
+            ReadOnlySequence<byte> originalSequence = sequence.AsReadOnlySequence;
+            long originalLength = originalSequence.Length;
+
+            // Create a SequencePosition 5 bytes into the first segment.
+            SequencePosition pos = originalSequence.GetPosition(5);
+
+            // Act
+            sequence.AdvanceTo(pos);
+            ReadOnlySequence<byte> roSequence = sequence.AsReadOnlySequence;
+
+            // Assert: new length should be originalLength - 5.
+            Assert.Equal(originalLength - 5, roSequence.Length);
+
+            // Verify that the first element is now the 6th element from original data.
+            SequenceReader<byte> reader = new SequenceReader<byte>(roSequence);
+            bool success = reader.TryRead(out byte firstValue);
+            Assert.True(success, "Failed to read from the sequence after advancing.");
+            Assert.Equal(6, firstValue);
+        }
+
+        /// <summary>
+        /// Tests that auto-increasing of MinimumSpanLength occurs as the sequence grows.
+        /// </summary>
+        [Fact]
+        public void AutoIncreaseMinimumSpanLength_WhenSequenceGrows_IncreasesMinimumSpanLength()
+        {
+            // Arrange
+            var sequence = new Sequence<byte>(arrayPool)
+            {
+                AutoIncreaseMinimumSpanLength = true,
+                MinimumSpanLength = 0
+            };
+
+            int iterations = 10;
+            int bytesPerIteration = 20;
+
+            // Act: Advance and accumulate data to grow the sequence.
+            for (int i = 0; i < iterations; i++)
+            {
+                Memory<byte> memory = sequence.GetMemory(bytesPerIteration);
+                sequence.Advance(bytesPerIteration);
+            }
+            long totalLength = sequence.AsReadOnlySequence.Length;
+            int expectedMinimum = (int)Math.Min(32 * 1024, totalLength / 2);
+
+            // Assert: MinimumSpanLength should be increased to at least expectedMinimum.
+            Assert.True(sequence.MinimumSpanLength >= expectedMinimum, 
+                $"Expected MinimumSpanLength to be at least {expectedMinimum} but was {sequence.MinimumSpanLength}.");
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/SpanPolyfillExtensionsTests.cs
+++ b/test/Nerdbank.Streams.Tests/SpanPolyfillExtensionsTests.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="SpanPolyfillExtensions"/> class.
+    /// </summary>
+    public class SpanPolyfillExtensionsTests
+    {
+        #region ReadAsync Tests
+
+        /// <summary>
+        /// Tests that ReadAsync throws an ArgumentNullException when the stream is null.
+        /// </summary>
+//         [Fact] [Error] (31-23)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task ReadAsync_NullStream_ThrowsArgumentNullException()
+//         {
+//             // Arrange
+//             Stream nullStream = null;
+//             Memory<byte> buffer = new byte[10];
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+//                 await SpanPolyfillExtensions.ReadAsync(nullStream, buffer));
+//         }
+
+        /// <summary>
+        /// Tests that ReadAsync correctly reads data when provided with array-backed Memory.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_ArrayBackedMemory_ReadsCorrectly()
+        {
+            // Arrange
+            byte[] sourceData = { 1, 2, 3, 4, 5 };
+            using MemoryStream stream = new MemoryStream(sourceData);
+            // Create array-backed memory.
+            Memory<byte> buffer = new byte[sourceData.Length];
+
+            // Act
+            int bytesRead = await stream.ReadAsync(buffer);
+            
+            // Assert
+            Assert.Equal(sourceData.Length, bytesRead);
+            Assert.Equal(sourceData, buffer.ToArray());
+        }
+
+        /// <summary>
+        /// Tests that ReadAsync correctly reads data when provided with non array-backed Memory.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_NonArrayBackedMemory_ReadsCorrectly()
+        {
+            // Arrange
+            byte[] sourceData = { 10, 20, 30, 40, 50, 60 };
+            using MemoryStream stream = new MemoryStream(sourceData);
+            // Create a non array-backed memory via a custom MemoryManager.
+            using TestMemoryManager manager = new TestMemoryManager(new byte[sourceData.Length]);
+            Memory<byte> buffer = manager.Memory;
+            // Overwrite the underlying memory with zeros to detect copy.
+            Array.Clear(manager.Data, 0, manager.Data.Length);
+
+            // Act
+            int bytesRead = await stream.ReadAsync(buffer);
+            
+            // Assert
+            Assert.Equal(sourceData.Length, bytesRead);
+            // The extension copies the read bytes into the provided memory.
+            byte[] result = buffer.ToArray();
+            Assert.Equal(sourceData, result);
+        }
+
+        #endregion
+
+        #region Read (Sync) Tests
+
+        /// <summary>
+        /// Tests that Read throws an ArgumentNullException when the stream is null.
+        /// </summary>
+//         [Fact] [Error] (94-72)CS8175 Cannot use ref local 'buffer' inside an anonymous method, lambda expression, or query expression
+//         public void Read_NullStream_ThrowsArgumentNullException()
+//         {
+//             // Arrange
+//             Stream nullStream = null;
+//             Span<byte> buffer = new byte[10];
+// 
+//             // Act & Assert
+//             Assert.Throws<ArgumentNullException>(() => nullStream.Read(buffer));
+//         }
+
+        /// <summary>
+        /// Tests that Read synchronously reads data correctly from an array-backed stream.
+        /// </summary>
+        [Fact]
+        public void Read_ArrayBackedMemory_ReadsCorrectly()
+        {
+            // Arrange
+            byte[] sourceData = { 100, 101, 102, 103 };
+            using MemoryStream stream = new MemoryStream(sourceData);
+            Span<byte> buffer = new byte[sourceData.Length];
+
+            // Act
+            int bytesRead = stream.Read(buffer);
+
+            // Assert
+            Assert.Equal(sourceData.Length, bytesRead);
+            Assert.Equal(sourceData, buffer.ToArray());
+        }
+
+        /// <summary>
+        /// Tests that Read returns zero and does not modify the buffer when given an empty buffer.
+        /// </summary>
+        [Fact]
+        public void Read_EmptyBuffer_ReturnsZero()
+        {
+            // Arrange
+            byte[] sourceData = { 1, 2, 3 };
+            using MemoryStream stream = new MemoryStream(sourceData);
+            Span<byte> buffer = Span<byte>.Empty;
+
+            // Act
+            int bytesRead = stream.Read(buffer);
+
+            // Assert
+            Assert.Equal(0, bytesRead);
+        }
+
+        #endregion
+
+        #region WriteAsync Tests (Stream)
+
+        /// <summary>
+        /// Tests that WriteAsync throws an ArgumentNullException when the stream is null.
+        /// </summary>
+//         [Fact] [Error] (150-23)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task WriteAsync_NullStream_ThrowsArgumentNullException()
+//         {
+//             // Arrange
+//             Stream nullStream = null;
+//             ReadOnlyMemory<byte> buffer = new byte[10];
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+//                 await SpanPolyfillExtensions.WriteAsync(nullStream, buffer));
+//         }
+
+        /// <summary>
+        /// Tests that WriteAsync correctly writes data when provided with array-backed Memory.
+        /// </summary>
+//         [Fact] [Error] (165-19)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task WriteAsync_ArrayBackedMemory_WritesCorrectly()
+//         {
+//             // Arrange
+//             byte[] dataToWrite = { 55, 66, 77, 88 };
+//             using MemoryStream stream = new MemoryStream();
+//             ReadOnlyMemory<byte> buffer = dataToWrite;
+// 
+//             // Act
+//             await SpanPolyfillExtensions.WriteAsync(stream, buffer);
+//             byte[] writtenData = stream.ToArray();
+// 
+//             // Assert
+//             Assert.Equal(dataToWrite, writtenData);
+//         }
+
+        /// <summary>
+        /// Tests that WriteAsync correctly writes data when provided with non array-backed Memory.
+        /// </summary>
+//         [Fact] [Error] (190-19)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task WriteAsync_NonArrayBackedMemory_WritesCorrectly()
+//         {
+//             // Arrange
+//             byte[] dataToWrite = { 200, 201, 202, 203, 204 };
+//             using MemoryStream stream = new MemoryStream();
+//             using TestMemoryManager manager = new TestMemoryManager(new byte[dataToWrite.Length]);
+//             // Copy our data into the manager's buffer so that we have a ReadOnlyMemory that is non array-backed.
+//             for (int i = 0; i < dataToWrite.Length; i++)
+//             {
+//                 manager.Data[i] = dataToWrite[i];
+//             }
+//             ReadOnlyMemory<byte> buffer = manager.Memory;
+// 
+//             // Act
+//             await SpanPolyfillExtensions.WriteAsync(stream, buffer);
+//             byte[] writtenData = stream.ToArray();
+// 
+//             // Assert
+//             Assert.Equal(dataToWrite, writtenData);
+//         }
+
+        #endregion
+
+        #region ReceiveAsync Tests (WebSocket)
+
+        /// <summary>
+        /// Tests that ReceiveAsync throws an ArgumentNullException when the WebSocket is null.
+        /// </summary>
+//         [Fact] [Error] (213-23)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task ReceiveAsync_NullWebSocket_ThrowsArgumentNullException()
+//         {
+//             // Arrange
+//             WebSocket nullWebSocket = null;
+//             Memory<byte> buffer = new byte[10];
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+//                 await SpanPolyfillExtensions.ReceiveAsync(nullWebSocket, buffer));
+//         }
+
+        /// <summary>
+        /// Tests that ReceiveAsync correctly receives data when provided with array-backed Memory.
+        /// </summary>
+//         [Fact] [Error] (238-65)CS1501 No overload for method 'ReceiveAsync' takes 1 arguments
+//         public async Task ReceiveAsync_ArrayBackedMemory_ReturnsCorrectResult()
+//         {
+//             // Arrange
+//             byte filler = 0xAA;
+//             int bufferSize = 8;
+//             FakeWebSocket fakeWebSocket = new FakeWebSocket((buffer, ct) =>
+//             {
+//                 // Fill the provided buffer with a repeating filler byte.
+//                 int count = Math.Min(buffer.Count, bufferSize);
+//                 for (int i = 0; i < count; i++)
+//                 {
+//                     buffer.Array[buffer.Offset + i] = filler;
+//                 }
+//                 return Task.FromResult(new WebSocketReceiveResult(count, WebSocketMessageType.Binary, true));
+//             });
+//             Memory<byte> buffer = new byte[bufferSize];
+// 
+//             // Act
+//             WebSocketReceiveResult result = await fakeWebSocket.ReceiveAsync(buffer);
+// 
+//             // Assert
+//             Assert.Equal(bufferSize, result.Count);
+//             byte[] expected = new byte[bufferSize];
+//             for (int i = 0; i < expected.Length; i++)
+//             {
+//                 expected[i] = filler;
+//             }
+//             Assert.Equal(expected, buffer.ToArray());
+//         }
+
+        /// <summary>
+        /// Tests that ReceiveAsync correctly receives data when provided with non array-backed Memory.
+        /// </summary>
+//         [Fact] [Error] (273-65)CS1501 No overload for method 'ReceiveAsync' takes 1 arguments
+//         public async Task ReceiveAsync_NonArrayBackedMemory_ReturnsCorrectResult()
+//         {
+//             // Arrange
+//             byte filler = 0xBB;
+//             int bufferSize = 6;
+//             FakeWebSocket fakeWebSocket = new FakeWebSocket((segment, ct) =>
+//             {
+//                 // Fill the provided ArraySegment with a repeating filler byte.
+//                 int count = Math.Min(segment.Count, bufferSize);
+//                 for (int i = 0; i < count; i++)
+//                 {
+//                     segment.Array[segment.Offset + i] = filler;
+//                 }
+//                 return Task.FromResult(new WebSocketReceiveResult(count, WebSocketMessageType.Binary, true));
+//             });
+//             using TestMemoryManager manager = new TestMemoryManager(new byte[bufferSize]);
+//             Memory<byte> buffer = manager.Memory;
+// 
+//             // Act
+//             WebSocketReceiveResult result = await fakeWebSocket.ReceiveAsync(buffer);
+// 
+//             // Assert
+//             Assert.Equal(bufferSize, result.Count);
+//             byte[] expected = new byte[bufferSize];
+//             for (int i = 0; i < expected.Length; i++)
+//             {
+//                 expected[i] = filler;
+//             }
+//             Assert.Equal(expected, buffer.ToArray());
+//         }
+
+        #endregion
+
+        #region SendAsync Tests (WebSocket)
+
+        /// <summary>
+        /// Tests that SendAsync throws an ArgumentNullException when the WebSocket is null.
+        /// </summary>
+//         [Fact] [Error] (301-23)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task SendAsync_NullWebSocket_ThrowsArgumentNullException()
+//         {
+//             // Arrange
+//             WebSocket nullWebSocket = null;
+//             ReadOnlyMemory<byte> buffer = new byte[10];
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+//                 await SpanPolyfillExtensions.SendAsync(nullWebSocket, buffer, WebSocketMessageType.Binary, true));
+//         }
+
+        /// <summary>
+        /// Tests that SendAsync correctly sends data when provided with array-backed Memory.
+        /// </summary>
+//         [Fact] [Error] (316-19)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task SendAsync_ArrayBackedMemory_SendsCorrectData()
+//         {
+//             // Arrange
+//             byte[] dataToSend = { 5, 6, 7, 8, 9 };
+//             FakeWebSocket fakeWebSocket = new FakeWebSocket();
+//             ReadOnlyMemory<byte> buffer = dataToSend;
+// 
+//             // Act
+//             await SpanPolyfillExtensions.SendAsync(fakeWebSocket, buffer, WebSocketMessageType.Binary, true);
+// 
+//             // Assert
+//             Assert.NotNull(fakeWebSocket.LastSentData);
+//             Assert.Equal(dataToSend.Length, fakeWebSocket.LastSentData.Count);
+//             Assert.Equal(dataToSend, fakeWebSocket.LastSentData.ToArray());
+//             Assert.Equal(WebSocketMessageType.Binary, fakeWebSocket.LastSentMessageType);
+//             Assert.True(fakeWebSocket.LastSentEndOfMessage);
+//         }
+
+        /// <summary>
+        /// Tests that SendAsync correctly sends data when provided with non array-backed Memory.
+        /// </summary>
+//         [Fact] [Error] (341-19)CS0103 The name 'SpanPolyfillExtensions' does not exist in the current context
+//         public async Task SendAsync_NonArrayBackedMemory_SendsCorrectData()
+//         {
+//             // Arrange
+//             byte[] dataToSend = { 150, 151, 152, 153 };
+//             FakeWebSocket fakeWebSocket = new FakeWebSocket();
+//             using TestMemoryManager manager = new TestMemoryManager(new byte[dataToSend.Length]);
+//             // Initialize the manager's buffer with our test data.
+//             Array.Copy(dataToSend, manager.Data, dataToSend.Length);
+//             ReadOnlyMemory<byte> buffer = manager.Memory;
+// 
+//             // Act
+//             await SpanPolyfillExtensions.SendAsync(fakeWebSocket, buffer, WebSocketMessageType.Text, false);
+// 
+//             // Assert
+//             Assert.NotNull(fakeWebSocket.LastSentData);
+//             Assert.Equal(dataToSend.Length, fakeWebSocket.LastSentData.Count);
+//             Assert.Equal(dataToSend, fakeWebSocket.LastSentData.ToArray());
+//             Assert.Equal(WebSocketMessageType.Text, fakeWebSocket.LastSentMessageType);
+//             Assert.False(fakeWebSocket.LastSentEndOfMessage);
+//         }
+
+        #endregion
+
+        #region Helper Classes
+
+        /// <summary>
+        /// A custom MemoryManager to simulate non array-backed Memory.
+        /// </summary>
+        private class TestMemoryManager : MemoryManager<byte>
+        {
+            public byte[] Data { get; }
+
+            public TestMemoryManager(byte[] data)
+            {
+                Data = data ?? throw new ArgumentNullException(nameof(data));
+            }
+
+            public override Span<byte> GetSpan() => Data;
+
+            public override MemoryHandle Pin(int elementIndex = 0) => Data.AsMemory().Pin();
+
+            public override void Unpin() { }
+
+            /// <summary>
+            /// Override TryGetArray to simulate non array-backed Memory by always returning false.
+            /// </summary>
+//             public override bool TryGetArray(out ArraySegment<byte> segment) [Error] (376-34)CS0507 'SpanPolyfillExtensionsTests.TestMemoryManager.TryGetArray(out ArraySegment<byte>)': cannot change access modifiers when overriding 'protected internal' inherited member 'MemoryManager<byte>.TryGetArray(out ArraySegment<byte>)'
+//             {
+//                 segment = default;
+//                 return false;
+//             }
+
+            protected override void Dispose(bool disposing) { }
+        }
+
+        /// <summary>
+        /// A fake WebSocket implementation for testing purposes.
+        /// </summary>
+//         private class FakeWebSocket : WebSocket [Error] (388-23)CS0534 'SpanPolyfillExtensionsTests.FakeWebSocket' does not implement inherited abstract member 'WebSocket.Dispose()'
+//         {
+//             private readonly Func<ArraySegment<byte>, CancellationToken, Task<WebSocketReceiveResult>> _receiveAsyncFunc;
+// 
+//             public FakeWebSocket()
+//             {
+//                 // Default behavior for SendAsync: capture the last sent data.
+//                 _receiveAsyncFunc = null;
+//             }
+// 
+//             /// <summary>
+//             /// Allows custom handling for ReceiveAsync.
+//             /// </summary>
+//             public FakeWebSocket(Func<ArraySegment<byte>, CancellationToken, Task<WebSocketReceiveResult>> receiveAsyncFunc)
+//             {
+//                 _receiveAsyncFunc = receiveAsyncFunc;
+//             }
+// 
+//             public System.Collections.Generic.List<byte> LastSentData { get; private set; }
+//             public WebSocketMessageType LastSentMessageType { get; private set; }
+//             public bool LastSentEndOfMessage { get; private set; }
+// 
+//             public override WebSocketCloseStatus? CloseStatus => null;
+// 
+//             public override string CloseStatusDescription => null;
+// 
+//             public override WebSocketState State => WebSocketState.Open;
+// 
+//             public override string SubProtocol => string.Empty;
+// 
+//             public override void Abort() { }
+// 
+//             public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+//                 => Task.CompletedTask;
+// 
+//             public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken)
+//                 => Task.CompletedTask;
+// 
+//             public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+//             {
+//                 if (_receiveAsyncFunc != null)
+//                 {
+//                     return _receiveAsyncFunc(buffer, cancellationToken);
+//                 }
+//                 else
+//                 {
+//                     // Default behavior: fill the buffer with 0xCC.
+//                     int count = buffer.Count;
+//                     for (int i = 0; i < count; i++)
+//                     {
+//                         buffer.Array[buffer.Offset + i] = 0xCC;
+//                     }
+//                     return Task.FromResult(new WebSocketReceiveResult(count, WebSocketMessageType.Binary, true));
+//                 }
+//             }
+// 
+//             public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+//             {
+//                 // Capture the sent data.
+//                 LastSentData = new System.Collections.Generic.List<byte>(buffer.Count);
+//                 for (int i = 0; i < buffer.Count; i++)
+//                 {
+//                     LastSentData.Add(buffer.Array[buffer.Offset + i]);
+//                 }
+//                 LastSentMessageType = messageType;
+//                 LastSentEndOfMessage = endOfMessage;
+//                 return Task.CompletedTask;
+//             }
+//         }
+
+        #endregion
+    }
+}

--- a/test/Nerdbank.Streams.Tests/StreamPipeReaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/StreamPipeReaderTests.cs
@@ -37,11 +37,12 @@ namespace Nerdbank.Streams.UnitTests
                 this.delayMilliseconds = delayMilliseconds;
             }
 
-//             public override async Task<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) [Error] (40-45)CS0508 'StreamPipeReaderTests.DelayingStream.ReadAsync(Memory<byte>, CancellationToken)': return type must be 'ValueTask<int>' to match overridden member 'MemoryStream.ReadAsync(Memory<byte>, CancellationToken)'
-//             {
-//                 await Task.Delay(delayMilliseconds, cancellationToken);
-//                 return await base.ReadAsync(buffer, cancellationToken);
-//             }
+            //             public override async Task<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) [Error] (40-45)CS0508 'StreamPipeReaderTests.DelayingStream.ReadAsync(Memory<byte>, CancellationToken)': return type must be 'ValueTask<int>' to match overridden member 'MemoryStream.ReadAsync(Memory<byte>, CancellationToken)'
+            //             {
+            //                 await Task.Delay(delayMilliseconds, cancellationToken);
+            //                 return await base.ReadAsync(buffer, cancellationToken);
+            //             }
+
 
             public override int Read(Span<byte> buffer)
             {

--- a/test/Nerdbank.Streams.Tests/StreamPipeReaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/StreamPipeReaderTests.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Nerdbank.Streams;
+using NSubstitute;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="StreamPipeReader"/> class.
+    /// </summary>
+    public class StreamPipeReaderTests
+    {
+        private readonly byte[] testData = new byte[] { 1, 2, 3, 4, 5 };
+
+        /// <summary>
+        /// A custom stream that is not readable to test constructor validation.
+        /// </summary>
+        private class NonReadableStream : MemoryStream
+        {
+            public override bool CanRead => false;
+        }
+
+        /// <summary>
+        /// A custom stream that introduces a delay in Read and ReadAsync calls to simulate blocking behavior.
+        /// </summary>
+        private class DelayingStream : MemoryStream
+        {
+            private readonly int delayMilliseconds;
+
+            public DelayingStream(byte[] buffer, int delayMilliseconds) : base(buffer)
+            {
+                this.delayMilliseconds = delayMilliseconds;
+            }
+
+//             public override async Task<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) [Error] (40-45)CS0508 'StreamPipeReaderTests.DelayingStream.ReadAsync(Memory<byte>, CancellationToken)': return type must be 'ValueTask<int>' to match overridden member 'MemoryStream.ReadAsync(Memory<byte>, CancellationToken)'
+//             {
+//                 await Task.Delay(delayMilliseconds, cancellationToken);
+//                 return await base.ReadAsync(buffer, cancellationToken);
+//             }
+
+            public override int Read(Span<byte> buffer)
+            {
+                Thread.Sleep(delayMilliseconds);
+                return base.Read(buffer);
+            }
+        }
+
+        /// <summary>
+        /// Tests that the constructor throws an <see cref="ArgumentNullException"/> when passed a null stream.
+        /// </summary>
+        [Fact]
+        public void Constructor_NullStream_ThrowsArgumentNullException()
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new StreamPipeReader(null!));
+        }
+
+        /// <summary>
+        /// Tests that the constructor throws an <see cref="ArgumentException"/> when the stream is not readable.
+        /// </summary>
+        [Fact]
+        public void Constructor_NonReadableStream_ThrowsArgumentException()
+        {
+            // Arrange
+            Stream nonReadable = new NonReadableStream();
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => new StreamPipeReader(nonReadable));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.AdvanceTo(SequencePosition, SequencePosition)"/> advances the buffer,
+        /// so that subsequent calls to <see cref="StreamPipeReader.TryRead(out ReadResult)"/> return false.
+        /// </summary>
+        [Fact]
+        public async Task AdvanceTo_AfterRead_ConsumesBuffer()
+        {
+            // Arrange
+            using var ms = new MemoryStream(testData);
+            var reader = new StreamPipeReader(ms);
+            ReadResult readResult = await reader.ReadAsync();
+            SequencePosition consumed = readResult.Buffer.Start;
+            SequencePosition examined = readResult.Buffer.Start;
+
+            // Act
+            reader.AdvanceTo(consumed, examined);
+
+            // Assert: After advancing, the buffer should have been consumed.
+            bool hasData = reader.TryRead(out ReadResult result);
+            Assert.False(hasData);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.ReadAsync(CancellationToken)"/> throws an <see cref="OperationCanceledException"/>
+        /// when the supplied CancellationToken is already canceled.
+        /// </summary>
+//         [Fact] [Error] (112-72)CS0029 Cannot implicitly convert type 'System.Threading.Tasks.ValueTask<System.IO.Pipelines.ReadResult>' to 'System.Threading.Tasks.Task' [Error] (112-72)CS1662 Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
+//         public async Task ReadAsync_AlreadyCanceledToken_ThrowsOperationCanceledException()
+//         {
+//             // Arrange
+//             using var ms = new MemoryStream(testData);
+//             var reader = new StreamPipeReader(ms);
+//             using var cts = new CancellationTokenSource();
+//             cts.Cancel();
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<OperationCanceledException>(() => reader.ReadAsync(cts.Token));
+//         }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.Complete(Exception?)"/> marks the reader as completed and disposes the stream
+        /// when leaveOpen is false.
+        /// </summary>
+        [Fact]
+        public void Complete_MarksReaderCompletedAndDisposesStream_WhenLeaveOpenIsFalse()
+        {
+            // Arrange
+            var ms = Substitute.ForPartsOf<MemoryStream>(testData);
+            var reader = new StreamPipeReader(ms, bufferSize: 4096, leaveOpen: false);
+
+            // Act
+            reader.Complete();
+
+            // Assert: After completion, TryRead should throw an InvalidOperationException.
+            Assert.Throws<InvalidOperationException>(() => reader.TryRead(out _));
+            // Also, the underlying stream is disposed.
+            Assert.Throws<ObjectDisposedException>(() => ms.Read(new byte[1], 0, 1));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.Complete(Exception?)"/> does not dispose the stream when leaveOpen is true.
+        /// </summary>
+        [Fact]
+        public void Complete_DoesNotDisposeStream_WhenLeaveOpenIsTrue()
+        {
+            // Arrange
+            using var ms = new MemoryStream(testData);
+            var reader = new StreamPipeReader(ms, bufferSize: 4096, leaveOpen: true);
+
+            // Act
+            reader.Complete();
+
+            // Assert: The stream remains accessible.
+            int value = ms.ReadByte();
+            // Since the stream position may be at the end, we only verify no exception was thrown.
+            Assert.True(true);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.ReadAsync(CancellationToken)"/> returns a <see cref="ReadResult"/>
+        /// with data when data is available in the stream.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_WhenDataAvailable_ReturnsDataAndNotCompleted()
+        {
+            // Arrange
+            using var ms = new MemoryStream(testData);
+            var reader = new StreamPipeReader(ms);
+
+            // Act
+            ReadResult result = await reader.ReadAsync();
+
+            // Assert
+            Assert.False(result.IsCanceled);
+            Assert.False(result.IsCompleted);
+            byte[] output = new byte[result.Buffer.Length];
+            result.Buffer.CopyTo(output);
+            Assert.Equal(testData, output);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.ReadAsync(CancellationToken)"/> returns a completed <see cref="ReadResult"/>
+        /// when the end-of-stream is reached.
+        /// </summary>
+        [Fact]
+        public async Task ReadAsync_WhenNoData_ReturnsCompletedResult()
+        {
+            // Arrange
+            using var ms = new MemoryStream(Array.Empty<byte>());
+            var reader = new StreamPipeReader(ms);
+
+            // Act
+            ReadResult result = await reader.ReadAsync();
+
+            // Assert
+            Assert.False(result.IsCanceled);
+            Assert.True(result.IsCompleted);
+            Assert.Equal(0, result.Buffer.Length);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.Read()"/> synchronously returns a <see cref="ReadResult"/> with data
+        /// when data is available.
+        /// </summary>
+        [Fact]
+        public void Read_WhenDataAvailable_ReturnsDataAndNotCompleted()
+        {
+            // Arrange
+            using var ms = new MemoryStream(testData);
+            var reader = new StreamPipeReader(ms);
+
+            // Act
+            ReadResult result = reader.Read();
+
+            // Assert
+            Assert.False(result.IsCanceled);
+            Assert.False(result.IsCompleted);
+            byte[] output = new byte[result.Buffer.Length];
+            result.Buffer.CopyTo(output);
+            Assert.Equal(testData, output);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.Read()"/> synchronously returns a completed <see cref="ReadResult"/>
+        /// when no data is available (end-of-stream).
+        /// </summary>
+        [Fact]
+        public void Read_WhenNoData_ReturnsCompletedResult()
+        {
+            // Arrange
+            using var ms = new MemoryStream(Array.Empty<byte>());
+            var reader = new StreamPipeReader(ms);
+
+            // Act
+            ReadResult result = reader.Read();
+
+            // Assert
+            Assert.False(result.IsCanceled);
+            Assert.True(result.IsCompleted);
+            Assert.Equal(0, result.Buffer.Length);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.TryRead(out ReadResult)"/> returns false when no data is available in the underlying stream.
+        /// </summary>
+        [Fact]
+        public void TryRead_WhenNoData_ReturnsFalse()
+        {
+            // Arrange
+            using var ms = new MemoryStream(Array.Empty<byte>());
+            var reader = new StreamPipeReader(ms);
+
+            // Act
+            bool result = reader.TryRead(out ReadResult readResult);
+
+            // Assert
+            Assert.False(result);
+            Assert.Equal(0, readResult.Buffer.Length);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.TryRead(out ReadResult)"/> returns true when data is buffered and not yet examined.
+        /// </summary>
+        [Fact]
+        public void TryRead_WhenDataAvailable_ReturnsTrue()
+        {
+            // Arrange
+            using var ms = new MemoryStream(testData);
+            var reader = new StreamPipeReader(ms);
+
+            // Force buffering by calling Read() to fill internal buffer.
+            ReadResult initialResult = reader.Read();
+
+            // Act
+            bool result = reader.TryRead(out ReadResult tryReadResult);
+
+            // Assert
+            Assert.True(result);
+            Assert.Equal(testData.Length, tryReadResult.Buffer.Length);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.OnWriterCompleted(Action{Exception?, object?}, object?)"/>
+        /// immediately invokes the callback when the writer is already completed.
+        /// </summary>
+        [Fact]
+        public void OnWriterCompleted_WhenWriterAlreadyCompleted_InvokesCallbackImmediately()
+        {
+            // Arrange
+            using var ms = new MemoryStream(Array.Empty<byte>());
+            var reader = new StreamPipeReader(ms);
+            bool callbackInvoked = false;
+            Exception? callbackException = null;
+
+            // Force writer completion by reading from an empty stream.
+            ReadResult result = reader.Read();
+
+            // Act
+            reader.OnWriterCompleted((ex, state) =>
+            {
+                callbackInvoked = true;
+                callbackException = ex;
+            }, null);
+
+            // Assert
+            Assert.True(callbackInvoked);
+            Assert.Null(callbackException);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="StreamPipeReader.OnWriterCompleted(Action{Exception?, object?}, object?)"/>
+        /// registers a callback that is later invoked when the writer completes.
+        /// </summary>
+        [Fact]
+        public async Task OnWriterCompleted_WhenWriterNotComplete_RegistersAndInvokesCallbackLater()
+        {
+            // Arrange
+            using var ms = new MemoryStream(testData);
+            var reader = new StreamPipeReader(ms);
+            bool callbackInvoked = false;
+            Exception? callbackException = null;
+            reader.OnWriterCompleted((ex, state) =>
+            {
+                callbackInvoked = true;
+                callbackException = ex;
+            }, null);
+
+            // Act: Read all data to force completion of the writer.
+            ReadResult result = await reader.ReadAsync();
+            while (!result.IsCompleted)
+            {
+                reader.AdvanceTo(result.Buffer.End);
+                result = await reader.ReadAsync();
+            }
+
+            // Wait a short time to ensure callback is invoked.
+            await Task.Delay(50);
+
+            // Assert
+            Assert.True(callbackInvoked);
+            Assert.Null(callbackException);
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/StreamPipeWriterTests.cs
+++ b/test/Nerdbank.Streams.Tests/StreamPipeWriterTests.cs
@@ -1,0 +1,303 @@
+// using Nerdbank.Streams;
+// using NSubstitute;
+// using System;
+// using System.IO;
+// using System.IO.Pipelines;
+// using System.Text;
+// using System.Threading;
+// using System.Threading.Tasks;
+// using Xunit;
+// 
+// namespace Nerdbank.Streams.UnitTests
+// {
+//     /// <summary>
+//     /// Unit tests for the <see cref = "StreamPipeWriter"/> class.
+//     /// </summary>
+// //     public class StreamPipeWriterTests [Error] (24-27)CS0122 'StreamPipeWriter' is inaccessible due to its protection level
+// //     {
+// //         private readonly MemoryStream _memoryStream;
+// //         private readonly StreamPipeWriter _writer; [Error] (19-26)CS0122 'StreamPipeWriter' is inaccessible due to its protection level
+//         public StreamPipeWriterTests()
+//         {
+//             // Use MemoryStream as the underlying stream.
+//             _memoryStream = new MemoryStream();
+//             _writer = new StreamPipeWriter(_memoryStream);
+//         }
+// 
+// #region Advance Tests
+//         /// <summary>
+//         /// Tests that Advance with positive bytes correctly causes the written data to be flushed to the stream.
+//         /// </summary>
+//         [Fact]
+//         public async Task Advance_WithPositiveBytes_WritesDataToStream()
+//         {
+//             // Arrange
+//             byte[] expectedData = Encoding.UTF8.GetBytes("abc");
+//             Memory<byte> memory = _writer.GetMemory(expectedData.Length);
+//             expectedData.CopyTo(memory);
+//             _writer.Advance(expectedData.Length);
+//             // Act
+//             FlushResult result = await _writer.FlushAsync();
+//             // Assert
+//             Assert.False(result.IsCanceled);
+//             Assert.True(result.IsCompleted);
+//             _memoryStream.Seek(0, SeekOrigin.Begin);
+//             byte[] actual = _memoryStream.ToArray();
+//             Assert.Equal(expectedData, actual);
+//         }
+// 
+//         /// <summary>
+//         /// Tests that calling Advance after the writer has been completed throws an InvalidOperationException.
+//         /// </summary>
+//         [Fact]
+//         public void Advance_AfterComplete_ThrowsInvalidOperationException()
+//         {
+//             // Arrange
+//             _writer.Complete();
+//             // Act & Assert
+//             Assert.Throws<InvalidOperationException>(() => _writer.Advance(1));
+//         }
+// 
+// #endregion
+// #region FlushAsync Tests
+//         /// <summary>
+//         /// Tests that FlushAsync flushes buffered data to the underlying stream.
+//         /// </summary>
+//         [Fact]
+//         public async Task FlushAsync_WithBufferedData_WritesDataToStream()
+//         {
+//             // Arrange
+//             byte[] expectedData = Encoding.UTF8.GetBytes("flushTest");
+//             Memory<byte> memory = _writer.GetMemory(expectedData.Length);
+//             expectedData.CopyTo(memory);
+//             _writer.Advance(expectedData.Length);
+//             // Act
+//             FlushResult result = await _writer.FlushAsync();
+//             // Assert
+//             Assert.False(result.IsCanceled);
+//             Assert.True(result.IsCompleted);
+//             _memoryStream.Seek(0, SeekOrigin.Begin);
+//             byte[] actual = _memoryStream.ToArray();
+//             Assert.Equal(expectedData, actual);
+//         }
+// 
+//         /// <summary>
+//         /// Tests that FlushAsync immediately throws an OperationCanceledException when provided a cancelled cancellation token.
+//         /// </summary>
+// //         [Fact] [Error] (94-72)CS0029 Cannot implicitly convert type 'System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult>' to 'System.Threading.Tasks.Task' [Error] (94-72)CS1662 Cannot convert lambda expression to intended delegate type because some of the return types in the block are not implicitly convertible to the delegate return type
+// //         public async Task FlushAsync_WhenCancellationTokenAlreadyCancelled_ThrowsOperationCanceledException()
+// //         {
+// //             // Arrange
+// //             using CancellationTokenSource cts = new CancellationTokenSource();
+// //             cts.Cancel();
+// //             // Act & Assert
+// //             await Assert.ThrowsAsync<OperationCanceledException>(() => _writer.FlushAsync(cts.Token));
+// //         }
+// 
+//         /// <summary>
+//         /// Tests that FlushAsync returns a canceled FlushResult when CancelPendingFlush is called during flushing.
+//         /// </summary>
+// //         [Fact] [Error] (106-13)CS0122 'StreamPipeWriter' is inaccessible due to its protection level [Error] (106-47)CS0122 'StreamPipeWriter' is inaccessible due to its protection level [Error] (112-43)CS0029 Cannot implicitly convert type 'System.Threading.Tasks.ValueTask<System.IO.Pipelines.FlushResult>' to 'System.Threading.Tasks.Task<System.IO.Pipelines.FlushResult>'
+// //         public async Task FlushAsync_WhenFlushIsCancelledViaCancelPendingFlush_ReturnsCanceledFlushResult()
+// //         {
+// //             // Arrange
+// //             // Use a slow stream to simulate delay in WriteAsync and FlushAsync.
+// //             using SlowWriteStream slowStream = new SlowWriteStream();
+// //             StreamPipeWriter slowWriter = new StreamPipeWriter(slowStream);
+// //             byte[] data = Encoding.UTF8.GetBytes("delayedData");
+// //             Memory<byte> memory = slowWriter.GetMemory(data.Length);
+// //             data.CopyTo(memory);
+// //             slowWriter.Advance(data.Length);
+// //             // Act
+// //             Task<FlushResult> flushTask = slowWriter.FlushAsync();
+// //             // Allow the flush to start.
+// //             await Task.Delay(50);
+// //             slowWriter.CancelPendingFlush();
+// //             FlushResult result = await flushTask;
+// //             // Assert
+// //             Assert.True(result.IsCanceled);
+// //             Assert.False(result.IsCompleted);
+// //         }
+// 
+// #endregion
+// #region Complete Tests
+//         /// <summary>
+//         /// Tests that calling Complete without buffered data triggers immediate reader completion callback.
+//         /// </summary>
+//         [Fact]
+//         public async Task Complete_WithoutBufferedData_InvokesOnReaderCompletedImmediately()
+//         {
+//             // Arrange
+//             bool callbackInvoked = false;
+//             Exception? callbackException = null;
+//             _writer.OnReaderCompleted((ex, state) =>
+//             {
+//                 callbackInvoked = true;
+//                 callbackException = ex;
+//             }, null);
+//             // Act
+//             _writer.Complete();
+//             // Give a small delay to allow callback to execute.
+//             await Task.Delay(50);
+//             // Assert
+//             Assert.True(callbackInvoked);
+//             Assert.Null(callbackException);
+//         }
+// 
+//         /// <summary>
+//         /// Tests that calling Complete with buffered data flushes the data and then invokes the reader completion callback.
+//         /// </summary>
+//         [Fact]
+//         public async Task Complete_WithBufferedData_FlushesDataAndInvokesOnReaderCompleted()
+//         {
+//             // Arrange
+//             byte[] expectedData = Encoding.UTF8.GetBytes("completeTest");
+//             Memory<byte> memory = _writer.GetMemory(expectedData.Length);
+//             expectedData.CopyTo(memory);
+//             _writer.Advance(expectedData.Length);
+//             bool callbackInvoked = false;
+//             Exception? callbackException = null;
+//             _writer.OnReaderCompleted((ex, state) =>
+//             {
+//                 callbackInvoked = true;
+//                 callbackException = ex;
+//             }, null);
+//             // Act
+//             _writer.Complete();
+//             // Wait sufficiently for implicit flush to complete.
+//             await Task.Delay(100);
+//             // Assert
+//             _memoryStream.Seek(0, SeekOrigin.Begin);
+//             byte[] actual = _memoryStream.ToArray();
+//             Assert.Equal(expectedData, actual);
+//             Assert.True(callbackInvoked);
+//             Assert.Null(callbackException);
+//         }
+// 
+// #endregion
+// #region GetMemory Tests
+//         /// <summary>
+//         /// Tests that GetMemory returns writable memory when the writer has not been completed.
+//         /// </summary>
+//         [Fact]
+//         public void GetMemory_BeforeComplete_ReturnsWritableMemory()
+//         {
+//             // Arrange
+//             int sizeHint = 10;
+//             // Act
+//             Memory<byte> memory = _writer.GetMemory(sizeHint);
+//             // Assert
+//             Assert.True(memory.Length >= sizeHint);
+//         }
+// 
+//         /// <summary>
+//         /// Tests that GetMemory throws an exception when called after completing the writer.
+//         /// </summary>
+//         [Fact]
+//         public void GetMemory_AfterComplete_ThrowsInvalidOperationException()
+//         {
+//             // Arrange
+//             _writer.Complete();
+//             // Act & Assert
+//             Assert.Throws<InvalidOperationException>(() => _writer.GetMemory(5));
+//         }
+// 
+// #endregion
+// #region GetSpan Tests
+//         /// <summary>
+//         /// Tests that GetSpan returns a writable span when the writer has not been completed.
+//         /// </summary>
+//         [Fact]
+//         public void GetSpan_BeforeComplete_ReturnsWritableSpan()
+//         {
+//             // Arrange
+//             int sizeHint = 10;
+//             // Act
+//             Span<byte> span = _writer.GetSpan(sizeHint);
+//             // Assert
+//             Assert.True(span.Length >= sizeHint);
+//         }
+// 
+//         /// <summary>
+//         /// Tests that GetSpan throws an exception when called after completing the writer.
+//         /// </summary>
+//         [Fact]
+//         public void GetSpan_AfterComplete_ThrowsInvalidOperationException()
+//         {
+//             // Arrange
+//             _writer.Complete();
+//             // Act & Assert
+//             Assert.Throws<InvalidOperationException>(() => _writer.GetSpan(5));
+//         }
+// 
+// #endregion
+// #region OnReaderCompleted Tests
+//         /// <summary>
+//         /// Tests that OnReaderCompleted when called on an already completed writer invokes the callback immediately with the writer exception.
+//         /// </summary>
+//         [Fact]
+//         public void OnReaderCompleted_WhenAlreadyCompleted_CallbackInvokedImmediately()
+//         {
+//             // Arrange
+//             Exception completeException = new Exception("Writer complete exception");
+//             bool callbackInvoked = false;
+//             Exception? callbackException = null;
+//             _writer.Complete(completeException);
+//             // Act
+//             _writer.OnReaderCompleted((ex, state) =>
+//             {
+//                 callbackInvoked = true;
+//                 callbackException = ex;
+//             }, null);
+//             // Assert
+//             Assert.True(callbackInvoked);
+//             Assert.Equal(completeException, callbackException);
+//         }
+// 
+//         /// <summary>
+//         /// Tests that registering a callback with OnReaderCompleted when the writer is not yet completed does not invoke the callback immediately,
+//         /// but does so after calling Complete.
+//         /// </summary>
+//         [Fact]
+//         public async Task OnReaderCompleted_WhenNotCompleted_CallbackInvokedAfterComplete()
+//         {
+//             // Arrange
+//             bool callbackInvoked = false;
+//             Exception? callbackException = null;
+//             _writer.OnReaderCompleted((ex, state) =>
+//             {
+//                 callbackInvoked = true;
+//                 callbackException = ex;
+//             }, null);
+//             // Act
+//             _writer.Complete();
+//             await Task.Delay(50);
+//             // Assert
+//             Assert.True(callbackInvoked);
+//             Assert.Null(callbackException);
+//         }
+// 
+// #endregion
+// #region SlowWriteStream Helper
+//         /// <summary>
+//         /// A helper stream that introduces delays in WriteAsync and FlushAsync to simulate slow operations, enabling cancellation tests.
+//         /// </summary>
+//         private class SlowWriteStream : MemoryStream
+//         {
+// //             public override async Task WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) [Error] (287-40)CS0508 'StreamPipeWriterTests.SlowWriteStream.WriteAsync(ReadOnlyMemory<byte>, CancellationToken)': return type must be 'ValueTask' to match overridden member 'MemoryStream.WriteAsync(ReadOnlyMemory<byte>, CancellationToken)'
+// //             {
+// //                 // Introduce a delay to simulate a long-running write.
+// //                 await Task.Delay(500, cancellationToken);
+// //                 await base.WriteAsync(buffer, cancellationToken);
+// //             }
+// 
+//             public override async Task FlushAsync(CancellationToken cancellationToken)
+//             {
+//                 // Introduce a delay to simulate a long-running flush.
+//                 await Task.Delay(500, cancellationToken);
+//                 await base.FlushAsync(cancellationToken);
+//             }
+//         }
+// #endregion
+//     }
+// }

--- a/test/Nerdbank.Streams.Tests/StringEncodingTests.cs
+++ b/test/Nerdbank.Streams.Tests/StringEncodingTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Text;
+using MessagePack;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="StringEncoding"/> class.
+    /// </summary>
+    public class StringEncodingTests
+    {
+        /// <summary>
+        /// Tests that the UTF8 field returns a valid UTF8Encoding instance configured to not emit a byte order mark.
+        /// </summary>
+//         [Fact] [Error] (20-33)CS0122 'StringEncoding' is inaccessible due to its protection level
+//         public void UTF8_Field_ReturnsValidEncoding()
+//         {
+//             // Arrange & Act
+//             Encoding encoding = StringEncoding.UTF8;
+// 
+//             // Assert
+//             Assert.NotNull(encoding);
+//             Assert.IsType<UTF8Encoding>(encoding);
+//             
+//             // Check that the encoding does not emit BOM.
+//             byte[] preamble = encoding.GetPreamble();
+//             Assert.Empty(preamble);
+//         }
+
+#if !NETCOREAPP
+        /// <summary>
+        /// Tests the GetString extension method to ensure it returns an empty string when provided with an empty byte span.
+        /// </summary>
+        [Fact]
+        public void GetString_WhenEmptySpan_ReturnsEmptyString()
+        {
+            // Arrange
+            Encoding encoding = StringEncoding.UTF8;
+            ReadOnlySpan<byte> emptySpan = ReadOnlySpan<byte>.Empty;
+
+            // Act
+            string result = encoding.GetString(emptySpan);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        /// <summary>
+        /// Tests the GetString extension method using a valid UTF8 byte span to verify it decodes correctly.
+        /// </summary>
+        [Fact]
+        public void GetString_WhenValidUtf8Bytes_ReturnsExpectedString()
+        {
+            // Arrange
+            Encoding encoding = StringEncoding.UTF8;
+            string expected = "Hello, World!";
+            byte[] encodedBytes = encoding.GetBytes(expected);
+            ReadOnlySpan<byte> byteSpan = new ReadOnlySpan<byte>(encodedBytes);
+
+            // Act
+            string result = encoding.GetString(byteSpan);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// Tests the GetString extension method to check proper decoding when provided with a subset of a byte array.
+        /// </summary>
+        [Fact]
+        public void GetString_WhenPartialSpan_ReturnsExpectedSubstring()
+        {
+            // Arrange
+            Encoding encoding = StringEncoding.UTF8;
+            string fullText = "Hello, World!";
+            string expectedSubstring = "World";
+            byte[] fullBytes = encoding.GetBytes(fullText);
+            int start = fullText.IndexOf(expectedSubstring, StringComparison.Ordinal);
+            int length = expectedSubstring.Length;
+            ReadOnlySpan<byte> partialSpan = new ReadOnlySpan<byte>(fullBytes, start, length);
+
+            // Act
+            string result = encoding.GetString(partialSpan);
+
+            // Assert
+            Assert.Equal(expectedSubstring, result);
+        }
+#endif
+    }
+}

--- a/test/Nerdbank.Streams.Tests/SubstreamReaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/SubstreamReaderTests.cs
@@ -1,0 +1,421 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NSubstitute;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="SubstreamReader"/> class.
+    /// </summary>
+    public class SubstreamReaderTests
+    {
+        /// <summary>
+        /// A helper stream class with CanRead overridden to false.
+        /// </summary>
+        private class NonReadableStream : MemoryStream
+        {
+            public override bool CanRead => false;
+        }
+
+        /// <summary>
+        /// Creates a MemoryStream containing the given header length and data.
+        /// </summary>
+        /// <param name="length">The substream length to encode in header.</param>
+        /// <param name="data">The substream data bytes.</param>
+        /// <returns>A MemoryStream containing header (4-byte little endian) followed by data.</returns>
+        private static MemoryStream CreateSubstreamMemoryStream(int length, byte[] data = null)
+        {
+            byte[] header = BitConverter.GetBytes(length);
+            byte[] streamData = header;
+            if (data != null)
+            {
+                using (var ms = new MemoryStream())
+                {
+                    ms.Write(header, 0, header.Length);
+                    ms.Write(data, 0, data.Length);
+                    streamData = ms.ToArray();
+                }
+            }
+            return new MemoryStream(streamData);
+        }
+
+        /// <summary>
+        /// Tests that the constructor throws an ArgumentNullException when the underlying stream is null.
+        /// </summary>
+//         [Fact] [Error] (56-60)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Constructor_NullUnderlyingStream_ThrowsArgumentNullException()
+//         {
+//             // Arrange
+//             Stream nullStream = null;
+// 
+//             // Act & Assert
+//             Assert.Throws<ArgumentNullException>(() => new SubstreamReader(nullStream));
+//         }
+
+        /// <summary>
+        /// Tests that the constructor throws an ArgumentException when the underlying stream is not readable.
+        /// </summary>
+//         [Fact] [Error] (69-56)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Constructor_NonReadableStream_ThrowsArgumentException()
+//         {
+//             // Arrange
+//             var nonReadable = new NonReadableStream();
+// 
+//             // Act & Assert
+//             Assert.Throws<ArgumentException>(() => new SubstreamReader(nonReadable));
+//         }
+
+        /// <summary>
+        /// Tests that the CanRead property always returns true.
+        /// </summary>
+//         [Fact] [Error] (80-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void CanRead_ReturnsTrue()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act
+//             bool canRead = reader.CanRead;
+// 
+//             // Assert
+//             Assert.True(canRead);
+//         }
+
+        /// <summary>
+        /// Tests that the CanSeek property always returns false.
+        /// </summary>
+//         [Fact] [Error] (97-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void CanSeek_ReturnsFalse()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act
+//             bool canSeek = reader.CanSeek;
+// 
+//             // Assert
+//             Assert.False(canSeek);
+//         }
+
+        /// <summary>
+        /// Tests that the CanWrite property always returns false.
+        /// </summary>
+//         [Fact] [Error] (114-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void CanWrite_ReturnsFalse()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act
+//             bool canWrite = reader.CanWrite;
+// 
+//             // Assert
+//             Assert.False(canWrite);
+//         }
+
+        /// <summary>
+        /// Tests that the CanTimeout property returns the underlying stream's CanTimeout value.
+        /// </summary>
+//         [Fact] [Error] (132-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void CanTimeout_ReturnsUnderlyingStreamCanTimeout()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             // MemoryStream's CanTimeout is false.
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act
+//             bool canTimeout = reader.CanTimeout;
+// 
+//             // Assert
+//             Assert.Equal(ms.CanTimeout, canTimeout);
+//         }
+
+        /// <summary>
+        /// Tests that accessing the Length property always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (149-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Length_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act & Assert
+//             Assert.Throws<NotSupportedException>(() => _ = reader.Length);
+//         }
+
+        /// <summary>
+        /// Tests that getting the Position property always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (163-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void PositionGet_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act & Assert
+//             Assert.Throws<NotSupportedException>(() => _ = reader.Position);
+//         }
+
+        /// <summary>
+        /// Tests that setting the Position property always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (177-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void PositionSet_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act & Assert
+//             Assert.Throws<NotSupportedException>(() => reader.Position = 10);
+//         }
+
+        /// <summary>
+        /// Tests that the Flush method always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (191-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Flush_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act & Assert
+//             Assert.Throws<NotSupportedException>(() => reader.Flush());
+//         }
+
+        /// <summary>
+        /// Tests that the FlushAsync method always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (205-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public async Task FlushAsync_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<NotSupportedException>(() => reader.FlushAsync(CancellationToken.None));
+//         }
+
+        /// <summary>
+        /// Tests that the Seek method always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (219-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Seek_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act & Assert
+//             Assert.Throws<NotSupportedException>(() => reader.Seek(0, SeekOrigin.Begin));
+//         }
+
+        /// <summary>
+        /// Tests that the SetLength method always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (233-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void SetLength_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act & Assert
+//             Assert.Throws<NotSupportedException>(() => reader.SetLength(100));
+//         }
+
+        /// <summary>
+        /// Tests that the Write method always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (247-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Write_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = Encoding.UTF8.GetBytes("test");
+// 
+//             // Act & Assert
+//             Assert.Throws<NotSupportedException>(() => reader.Write(buffer, 0, buffer.Length));
+//         }
+
+        /// <summary>
+        /// Tests that the WriteAsync method always throws a NotSupportedException.
+        /// </summary>
+//         [Fact] [Error] (262-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public async Task WriteAsync_AlwaysThrowsNotSupportedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = Encoding.UTF8.GetBytes("test");
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<NotSupportedException>(() => reader.WriteAsync(buffer, 0, buffer.Length, CancellationToken.None));
+//         }
+
+        /// <summary>
+        /// Tests that the Read method returns zero when the substream header indicates an EOF (length of zero).
+        /// </summary>
+//         [Fact] [Error] (277-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Read_SubstreamEof_ReturnsZero()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0); // header indicates 0 length => EOF.
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = new byte[10];
+// 
+//             // Act
+//             int bytesRead = reader.Read(buffer, 0, buffer.Length);
+// 
+//             // Assert
+//             Assert.Equal(0, bytesRead);
+//         }
+
+        /// <summary>
+        /// Tests that the Read method correctly reads data when a valid substream header and data are provided.
+        /// </summary>
+//         [Fact] [Error] (297-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Read_NormalRead_ReturnsCorrectBytes()
+//         {
+//             // Arrange
+//             string expectedText = "Hello";
+//             byte[] data = Encoding.UTF8.GetBytes(expectedText);
+//             using var ms = CreateSubstreamMemoryStream(data.Length, data);
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = new byte[10];
+// 
+//             // Act
+//             int bytesRead = reader.Read(buffer, 0, buffer.Length);
+//             // A subsequent read should hit EOF.
+//             int secondRead = reader.Read(buffer, 0, buffer.Length);
+// 
+//             // Assert
+//             Assert.Equal(data.Length, bytesRead);
+//             Assert.Equal(0, secondRead);
+//             string actualText = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+//             Assert.Equal(expectedText, actualText);
+//         }
+
+        /// <summary>
+        /// Tests that the Read method throws an EndOfStreamException when the header is incomplete.
+        /// </summary>
+//         [Fact] [Error] (322-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void Read_HeaderIncomplete_ThrowsEndOfStreamException()
+//         {
+//             // Arrange
+//             // Create a MemoryStream with fewer than 4 bytes (e.g., 2 bytes).
+//             byte[] incompleteHeader = new byte[] { 0x01, 0x02 };
+//             using var ms = new MemoryStream(incompleteHeader);
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = new byte[10];
+// 
+//             // Act & Assert
+//             Assert.Throws<EndOfStreamException>(() => reader.Read(buffer, 0, buffer.Length));
+//         }
+
+        /// <summary>
+        /// Tests that the ReadAsync method returns zero when the substream header indicates an EOF (length of zero).
+        /// </summary>
+//         [Fact] [Error] (337-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public async Task ReadAsync_SubstreamEof_ReturnsZero()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0); // header indicates 0 length => EOF.
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = new byte[10];
+// 
+//             // Act
+//             int bytesRead = await reader.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None);
+// 
+//             // Assert
+//             Assert.Equal(0, bytesRead);
+//         }
+
+        /// <summary>
+        /// Tests that the ReadAsync method correctly reads data when a valid substream header and data are provided.
+        /// </summary>
+//         [Fact] [Error] (357-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public async Task ReadAsync_NormalRead_ReturnsCorrectBytes()
+//         {
+//             // Arrange
+//             string expectedText = "World";
+//             byte[] data = Encoding.UTF8.GetBytes(expectedText);
+//             using var ms = CreateSubstreamMemoryStream(data.Length, data);
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = new byte[10];
+// 
+//             // Act
+//             int bytesRead = await reader.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None);
+//             int secondRead = await reader.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None);
+// 
+//             // Assert
+//             Assert.Equal(data.Length, bytesRead);
+//             Assert.Equal(0, secondRead);
+//             string actualText = Encoding.UTF8.GetString(buffer, 0, bytesRead);
+//             Assert.Equal(expectedText, actualText);
+//         }
+
+        /// <summary>
+        /// Tests that the ReadAsync method throws an EndOfStreamException when the header is incomplete.
+        /// </summary>
+//         [Fact] [Error] (380-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public async Task ReadAsync_HeaderIncomplete_ThrowsEndOfStreamException()
+//         {
+//             // Arrange
+//             byte[] incompleteHeader = new byte[] { 0x01, 0x02 };
+//             using var ms = new MemoryStream(incompleteHeader);
+//             var reader = new SubstreamReader(ms);
+//             byte[] buffer = new byte[10];
+// 
+//             // Act & Assert
+//             await Assert.ThrowsAsync<EndOfStreamException>(() => reader.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None));
+//         }
+
+        /// <summary>
+        /// Tests that calling Dispose sets the IsDisposed property to true.
+        /// </summary>
+//         [Fact] [Error] (395-30)CS0122 'SubstreamReader' is inaccessible due to its protection level [Error] (401-32)CS0122 'SubstreamReader.IsDisposed' is inaccessible due to its protection level
+//         public void Dispose_SetsIsDisposedTrue()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+// 
+//             // Act
+//             reader.Dispose();
+// 
+//             // Assert
+//             Assert.True(reader.IsDisposed);
+//         }
+
+        /// <summary>
+        /// Tests that methods throw an ObjectDisposedException after the SubstreamReader has been disposed.
+        /// </summary>
+//         [Fact] [Error] (412-30)CS0122 'SubstreamReader' is inaccessible due to its protection level
+//         public void MethodsAfterDispose_ThrowObjectDisposedException()
+//         {
+//             // Arrange
+//             using var ms = CreateSubstreamMemoryStream(0);
+//             var reader = new SubstreamReader(ms);
+//             reader.Dispose();
+// 
+//             // Act & Assert
+//             Assert.Throws<ObjectDisposedException>(() => { var _ = reader.Length; });
+//             Assert.Throws<ObjectDisposedException>(() => reader.Flush());
+//             Assert.Throws<ObjectDisposedException>(() => reader.Seek(0, SeekOrigin.Begin));
+//         }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/ThrowHelperTests.cs
+++ b/test/Nerdbank.Streams.Tests/ThrowHelperTests.cs
@@ -1,0 +1,42 @@
+using System;
+using Nerdbank.Streams;
+using Xunit;
+
+namespace Nerdbank.Streams.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="ThrowHelper"/> class.
+    /// </summary>
+    public class ThrowHelperTests
+    {
+        /// <summary>
+        /// Tests that the ThrowArgumentOutOfRangeException method throws an ArgumentOutOfRangeException
+        /// with the expected parameter name when a non-null parameter name is provided.
+        /// </summary>
+//         [Fact] [Error] (23-78)CS0122 'ThrowHelper' is inaccessible due to its protection level
+//         public void ThrowArgumentOutOfRangeException_WithValidParameterName_ThrowsExceptionWithParameterName()
+//         {
+//             // Arrange
+//             string paramName = "testParam";
+// 
+//             // Act & Assert
+//             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => ThrowHelper.ThrowArgumentOutOfRangeException(paramName));
+//             Assert.Equal(paramName, exception.ParamName);
+//         }
+
+        /// <summary>
+        /// Tests that the ThrowArgumentOutOfRangeException method throws an ArgumentOutOfRangeException
+        /// with a null parameter name when null is provided.
+        /// </summary>
+//         [Fact] [Error] (38-78)CS0122 'ThrowHelper' is inaccessible due to its protection level
+//         public void ThrowArgumentOutOfRangeException_WithNullParameterName_ThrowsExceptionWithNullParameterName()
+//         {
+//             // Arrange
+//             string? paramName = null;
+// 
+//             // Act & Assert
+//             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => ThrowHelper.ThrowArgumentOutOfRangeException(paramName));
+//             Assert.Null(exception.ParamName);
+//         }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/UnownedPipeReaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/UnownedPipeReaderTests.cs
@@ -1,0 +1,147 @@
+// using System;
+// using System.IO.Pipelines;
+// using System.Threading;
+// using System.Threading.Tasks;
+// using NSubstitute;
+// using Nerdbank.Streams;
+// using Xunit;
+// 
+// namespace Nerdbank.Streams.UnitTests
+// {
+//     /// <summary>
+//     /// Unit tests for the <see cref="UnownedPipeReader"/> class.
+//     /// </summary>
+// //     public class UnownedPipeReaderTests [Error] (26-38)CS0122 'UnownedPipeReader' is inaccessible due to its protection level
+// //     {
+// //         private readonly PipeReader _mockUnderlyingReader;
+// //         private readonly UnownedPipeReader _unownedPipeReader; [Error] (17-26)CS0122 'UnownedPipeReader' is inaccessible due to its protection level
+//         private const string ExpectedExceptionMessage = "This object is owned by another context and should not be accessed from another.";
+// 
+//         /// <summary>
+//         /// Initializes a new instance of the <see cref="UnownedPipeReaderTests"/> class and sets up the underlying PipeReader mock.
+//         /// </summary>
+//         public UnownedPipeReaderTests()
+//         {
+//             _mockUnderlyingReader = Substitute.For<PipeReader>();
+//             _unownedPipeReader = new UnownedPipeReader(_mockUnderlyingReader);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that CancelPendingRead delegates the call to the underlying PipeReader.
+//         /// </summary>
+//         [Fact]
+//         public void CancelPendingRead_WhenCalled_DelegatesToUnderlyingReader()
+//         {
+//             // Act
+//             _unownedPipeReader.CancelPendingRead();
+// 
+//             // Assert
+//             _mockUnderlyingReader.Received(1).CancelPendingRead();
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that AdvanceTo with a single SequencePosition parameter throws an exception indicating the object is unowned.
+//         /// </summary>
+//         [Fact]
+//         public void AdvanceTo_SingleParameter_ThrowsException()
+//         {
+//             // Arrange
+//             SequencePosition position = default;
+// 
+//             // Act & Assert
+//             Exception ex = Assert.Throws<Exception>(() => _unownedPipeReader.AdvanceTo(position));
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that AdvanceTo with both consumed and examined SequencePosition parameters throws an exception indicating the object is unowned.
+//         /// </summary>
+//         [Fact]
+//         public void AdvanceTo_TwoParameters_ThrowsException()
+//         {
+//             // Arrange
+//             SequencePosition consumed = default;
+//             SequencePosition examined = default;
+// 
+//             // Act & Assert
+//             Exception ex = Assert.Throws<Exception>(() => _unownedPipeReader.AdvanceTo(consumed, examined));
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that Complete throwing an exception when invoked with a null exception.
+//         /// </summary>
+//         [Fact]
+//         public void Complete_NullException_ThrowsException()
+//         {
+//             // Act & Assert
+//             Exception ex = Assert.Throws<Exception>(() => _unownedPipeReader.Complete(null));
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that Complete throwing an exception when invoked with a non-null exception.
+//         /// </summary>
+//         [Fact]
+//         public void Complete_WithException_ThrowsException()
+//         {
+//             // Arrange
+//             Exception testException = new Exception("Test");
+// 
+//             // Act & Assert
+//             Exception ex = Assert.Throws<Exception>(() => _unownedPipeReader.Complete(testException));
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that CompleteAsync throws an exception when invoked with a null exception.
+//         /// </summary>
+//         [Fact]
+//         public async Task CompleteAsync_NullException_ThrowsException()
+//         {
+//             // Act & Assert
+//             Exception ex = await Assert.ThrowsAsync<Exception>(() => _unownedPipeReader.CompleteAsync(null).AsTask());
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that CompleteAsync throws an exception when invoked with a non-null exception.
+//         /// </summary>
+//         [Fact]
+//         public async Task CompleteAsync_WithException_ThrowsException()
+//         {
+//             // Arrange
+//             Exception testException = new Exception("Test");
+// 
+//             // Act & Assert
+//             Exception ex = await Assert.ThrowsAsync<Exception>(() => _unownedPipeReader.CompleteAsync(testException).AsTask());
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that ReadAsync throws an exception when called.
+//         /// </summary>
+//         [Fact]
+//         public async Task ReadAsync_WhenCalled_ThrowsException()
+//         {
+//             // Act & Assert
+//             Exception ex = await Assert.ThrowsAsync<Exception>(() => _unownedPipeReader.ReadAsync(CancellationToken.None).AsTask());
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+// 
+//         /// <summary>
+//         /// Verifies that TryRead throws an exception when called.
+//         /// </summary>
+//         [Fact]
+//         public void TryRead_WhenCalled_ThrowsException()
+//         {
+//             // Act & Assert
+//             Exception ex = Assert.Throws<Exception>(() =>
+//             {
+//                 ReadResult result;
+//                 _unownedPipeReader.TryRead(out result);
+//             });
+//             Assert.Equal(ExpectedExceptionMessage, ex.Message);
+//         }
+//     }
+// }

--- a/test/Nerdbank.Streams.Tests/UtilitiesTests.cs
+++ b/test/Nerdbank.Streams.Tests/UtilitiesTests.cs
@@ -1,0 +1,95 @@
+using MessagePack;
+using NSubstitute;
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace MessagePack.UnitTests
+{
+    /// <summary>
+    /// Unit tests for the <see cref="Utilities"/> class.
+    /// </summary>
+    public class UtilitiesTests
+    {
+        /// <summary>
+        /// Tests the GetWriterBytes method with a valid action delegate that writes an Int32 to the underlying writer.
+        /// The expected outcome is that the returned byte array correctly encodes the input integer.
+        /// </summary>
+//         [Fact] [Error] (25-29)CS0122 'Utilities' is inaccessible due to its protection level
+//         public void GetWriterBytes_WithValidAction_ReturnsExpectedByteArray()
+//         {
+//             // Arrange
+//             int valueToWrite = 42;
+//             
+//             // Act
+//             byte[] result = Utilities.GetWriterBytes(valueToWrite, (ref MessagePackWriter writer, int arg) =>
+//             {
+//                 // Write the integer using MessagePackWriter's WriteInt32 method.
+//                 // This should result in a MessagePack encoded integer.
+//                 writer.WriteInt32(arg);
+//             });
+// 
+//             // Assert
+//             Assert.NotNull(result);
+//             Assert.NotEmpty(result);
+// 
+//             // To verify, decode the written value using MessagePackReader.
+//             var reader = new MessagePackReader(result);
+//             int decoded = reader.ReadInt32();
+//             Assert.Equal(valueToWrite, decoded);
+//         }
+
+        /// <summary>
+        /// Tests that GetWriterBytes throws a NullReferenceException when a null action delegate is passed.
+        /// The expected outcome is that an exception is thrown.
+        /// </summary>
+//         [Fact] [Error] (51-32)CS0122 'Utilities' is inaccessible due to its protection level
+//         public void GetWriterBytes_WithNullAction_ThrowsNullReferenceException()
+//         {
+//             // Arrange
+//             int valueToWrite = 42;
+//             Action act = () => Utilities.GetWriterBytes(valueToWrite, null);
+// 
+//             // Act & Assert
+//             Assert.Throws<NullReferenceException>(act);
+//         }
+
+        /// <summary>
+        /// Tests the GetMemoryCheckResult extension method when the underlying IBufferWriter returns a non-empty memory block.
+        /// The expected outcome is that the returned memory block matches the one provided by GetMemory.
+        /// </summary>
+//         [Fact] [Error] (70-58)CS1061 'IBufferWriter<byte>' does not contain a definition for 'GetMemoryCheckResult' and no accessible extension method 'GetMemoryCheckResult' accepting a first argument of type 'IBufferWriter<byte>' could be found (are you missing a using directive or an assembly reference?)
+//         public void GetMemoryCheckResult_WithNonEmptyMemory_ReturnsSameMemory()
+//         {
+//             // Arrange
+//             var expectedArray = new byte[10];
+//             IBufferWriter<byte> fakeBufferWriter = Substitute.For<IBufferWriter<byte>>();
+//             fakeBufferWriter.GetMemory(Arg.Any<int>()).Returns(expectedArray);
+// 
+//             // Act
+//             Memory<byte> resultMemory = fakeBufferWriter.GetMemoryCheckResult();
+// 
+//             // Assert
+//             Assert.False(resultMemory.IsEmpty);
+//             Assert.Equal(expectedArray.Length, resultMemory.Length);
+//         }
+
+        /// <summary>
+        /// Tests that GetMemoryCheckResult throws an InvalidOperationException when the underlying IBufferWriter returns an empty memory block.
+        /// The expected outcome is that the exception message contains the expected error message and the type name of the buffer writer.
+        /// </summary>
+//         [Fact] [Error] (90-115)CS1061 'IBufferWriter<byte>' does not contain a definition for 'GetMemoryCheckResult' and no accessible extension method 'GetMemoryCheckResult' accepting a first argument of type 'IBufferWriter<byte>' could be found (are you missing a using directive or an assembly reference?)
+//         public void GetMemoryCheckResult_WithEmptyMemory_ThrowsInvalidOperationException()
+//         {
+//             // Arrange
+//             IBufferWriter<byte> fakeBufferWriter = Substitute.For<IBufferWriter<byte>>();
+//             fakeBufferWriter.GetMemory(Arg.Any<int>()).Returns(Memory<byte>.Empty);
+//             string expectedMessagePart = "The underlying IBufferWriter<byte>.GetMemory(int) method returned an empty memory block, which is not allowed. This is a bug in ";
+// 
+//             // Act & Assert
+//             InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => fakeBufferWriter.GetMemoryCheckResult());
+//             Assert.Contains(expectedMessagePart, exception.Message);
+//             Assert.Contains(fakeBufferWriter.GetType().FullName, exception.Message);
+//         }
+    }
+}


### PR DESCRIPTION
### Context
Generated with very early preview of unit tests generation tool. Trying to evaluate if there is any hope of that being useful and what would need to be worked on to achieve usefulness.

### Technical data

Baseline (main):
```
Test summary: total: 1985, failed: 0, succeeded: 1969, skipped: 16, duration: 9.4s
```

Target (generated):
```
Test summary: total: 1038, failed: 6, succeeded: 1022, skipped: 10, duration: 10.6s 
```

(The after seem to have lest test as I removed net472 targetting. otherwise 198 tests were generated)


| AssemblyName           | LineRateBefore | LineRateAfter | LineRateDiff | BranchRateBefore | BranchRateAfter | BranchRateDiff |
| ---------------------- | -------------- | ------------- | ------------ | ---------------- | --------------- | -------------- |
| Nerdbank.Streams       | 71.10 %        | 69.18 %       | -1.92 %      | 69.36 %          | 61.43 %         | -7.93 %        |


### More comments
 * Still just heuristical version (so might not follow convention and references of the repo)
 * Very few and dummy code fixers - so we fallback a lot to commenting out tests with compilation diagnostic
 * No runtime feedback yet - so tests that crash/fail during runtime are kept