### PR TITLE
feat(actions): add nuget trusted publishing & fix duplicated permission declaration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,7 @@ jobs:
     runs-on: windows-latest
     environment: Signing
     permissions:
-      id-token: write # Required for Azure CLI Login
-    permissions:
+      id-token: write # Required for Azure / NuGet CLI Login
       actions: read
       contents: write
     steps:
@@ -83,7 +82,7 @@ jobs:
         run-id: ${{ steps.findrunid.outputs.runid }}
         github-token: ${{ github.token }}
 
-# Login to Azure using a ServicePrincipal configured to authenticate agaist a GitHub Action
+    # Login to Azure using a ServicePrincipal configured to authenticate agaist a GitHub Action
     - name: 🪪 Authorize signing
       uses: azure/login@v2.3.0
       with:
@@ -129,6 +128,13 @@ jobs:
       working-directory: ${{ runner.temp }}
       if: ${{ env.NPM_API_KEY_DEFINED == 'true' }}
 
+    - name: 🚀 NuGet login for push
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+      if: ${{ env.NUGET_API_KEY_DEFINED == 'true' }}
+
     - name: 🚀 Push NuGet packages
-      run: dotnet nuget push ${{ runner.temp }}\deployables\NuGet\*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ secrets.NUGET_API_KEY }}'
+      run: dotnet nuget push ${{ runner.temp }}\deployables\NuGet\*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ steps.nuget-login.outputs.NUGET_API_KEY }}'
       if: ${{ env.NUGET_API_KEY_DEFINED == 'true' }}


### PR DESCRIPTION
#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (Nerdbank in this case).  
- The old `secrets. NUGET_API_KEY` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `Nerdbank`).  
   - **Repository owner:** your GitHub org/user (e.g. `dotnet`).  
   - **Repository name:** repository name (e.g. `Nerdbank.Streams`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `release.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.

I also fixed it as it looks duplicated:

- Before:
```yaml
    permissions:
      id-token: write
    permissions:
      actions: read
      contents: write
```
- After:
```yaml
    permissions:
      id-token: write
      actions: read
      contents: write
```