### PR TITLE
Stabilize window frame compatibility test

### DIFF
--- a/test/Nerdbank.Streams.Tests/MultiplexingStreamWindowFrameCompatTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStreamWindowFrameCompatTests.cs
@@ -22,7 +22,7 @@ using Xunit;
 /// </remarks>
 public class MultiplexingStreamWindowFrameCompatTests : TestBase
 {
-    private int droppedFrames;
+    private readonly AsyncManualResetEvent windowFrameDropped = new();
 
     public MultiplexingStreamWindowFrameCompatTests(ITestOutputHelper logger)
         : base(logger)
@@ -64,9 +64,9 @@ public class MultiplexingStreamWindowFrameCompatTests : TestBase
             },
             this.TimeoutToken);
 
-        // Let the sender run ahead with nobody reading, so it is certain to exhaust its window and ask for
-        // a larger one. A prompt reader on a zero-latency pipe may never let the sender stall at all.
-        await Task.Delay(ExpectedTimeout, this.TimeoutToken);
+        // Wait until the sender has exhausted its window before reading. A prompt reader on a zero-latency
+        // pipe may otherwise keep up with the sender so well that it never stalls.
+        await this.windowFrameDropped.WaitAsync(this.TimeoutToken);
 
         byte[] received = new byte[TransferSize];
         int bytesRead = 0;
@@ -79,10 +79,6 @@ public class MultiplexingStreamWindowFrameCompatTests : TestBase
 
         await sendTask.WithCancellation(this.TimeoutToken);
         Assert.Equal<byte>(payload, received);
-
-        // Guard against a vacuous pass: the transfer is far larger than the default window,
-        // so the sender must have stalled and asked for a larger one at least once.
-        Assert.NotEqual(0, this.droppedFrames);
 
         await mx1.DisposeAsync();
         await mx2.DisposeAsync();
@@ -108,7 +104,7 @@ public class MultiplexingStreamWindowFrameCompatTests : TestBase
             int code = peek.ReadInt32();
             if (code is ChannelWindowAdjust or ChannelWindowGrowthRequest)
             {
-                Interlocked.Increment(ref this.droppedFrames);
+                this.windowFrameDropped.Set();
                 this.Logger.WriteLine("Dropping frame with control code {0}.", code);
                 continue;
             }


### PR DESCRIPTION
## Summary

- replace the fixed 200 ms delay with synchronization on the relay observing a dropped window frame
- ensure the receiver starts draining only after the sender has actually exhausted its window

## Root cause

`TransferSucceeds_WhenWindowFramesAreDropped` assumed its background writer would exhaust the channel window within 200 ms. Under load in the Windows .NET Framework test run, the writer could start late; once the receiver began reading, it kept up on the zero-latency pipe and no growth request was emitted. The final non-vacuous assertion then failed.

This is unrelated to #1148, which only changes TypeScript ESLint dependencies. The same test and assertion also failed on `main` in workflow run https://github.com/dotnet/Nerdbank.Streams/actions/runs/30677694206.

## Validation

- affected test passes on net8.0 and net472
- affected test passes 20 consecutive net472 runs