### PR TITLE
Merge Library.Template updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.302@sha256:ed034a8bf0b24ded0cbbac07e17825d8e9ebfe21e308191d0f7421eaf5ad4664
+FROM mcr.microsoft.com/dotnet/sdk:10.0.302@sha256:72dd743782f2ae7e5476fd64f6a460045e3998dc862218b80e6944cba79a01b0
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.302@sha256:72dd743782f2ae7e5476fd64f6a460045e3998dc862218b80e6944cba79a01b0
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1fc6e423f543119c406d24e2e687d67c569f18f04a37a8b0005d80ad0dcee80
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
         }
       shell: pwsh
       timeout-minutes: 3
-      continue-on-error: true
 
   docs:
     name: 📃 Docs

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicrosoftTestingPlatformVersion>2.3.2</MicrosoftTestingPlatformVersion>
+    <MicrosoftTestingPlatformVersion>2.3.3</MicrosoftTestingPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Put repo-specific PackageVersion items in this group. -->

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.302",
+    "version": "10.0.400",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/tools/Get-CodeCovTool.ps1
+++ b/tools/Get-CodeCovTool.ps1
@@ -10,15 +10,15 @@ Param(
 )
 
 if ($IsMacOS) {
-    $codeCovUrl = "https://uploader.codecov.io/latest/macos/codecov"
+    $codeCovUrl = "https://cli.codecov.io/latest/macos/codecov"
     $toolName = 'codecov'
 }
 elseif ($IsLinux) {
-    $codeCovUrl = "https://uploader.codecov.io/latest/linux/codecov"
+    $codeCovUrl = "https://cli.codecov.io/latest/linux/codecov"
     $toolName = 'codecov'
 }
 else {
-    $codeCovUrl = "https://uploader.codecov.io/latest/windows/codecov.exe"
+    $codeCovUrl = "https://cli.codecov.io/latest/windows/codecov.exe"
     $toolName = 'codecov.exe'
 }
 
@@ -41,7 +41,7 @@ Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
 }
 
 $toolsPath = & "$PSScriptRoot\Get-TempToolsPath.ps1"
-$binaryToolsPath = Join-Path $toolsPath codecov
+$binaryToolsPath = Join-Path $toolsPath codecov-cli
 $testingPath = Join-Path $binaryToolsPath unverified
 $finalToolPath = Join-Path $binaryToolsPath $toolName
 
@@ -52,13 +52,20 @@ if (!(Test-Path $finalToolPath)) {
     $tool = Get-FileFromWeb $codeCovUrl $testingPath
     $sha = Get-FileFromWeb "$codeCovUrl$shaSuffix" $testingPath
     $sig = Get-FileFromWeb "$codeCovUrl$sigSuffix" $testingPath
-    $key = Get-FileFromWeb https://keybase.io/codecovsecurity/pgp_keys.asc $testingPath
+    $key = Get-FileFromWeb https://keybase.io/codecovsecops/pgp_keys.asc $testingPath
 
     if ((Get-Command gpg -ErrorAction SilentlyContinue)) {
         Write-Host "Importing codecov key" -ForegroundColor Yellow
         gpg --import $key
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to import the Codecov signature verification key."
+        }
+
         Write-Host "Verifying signature on codecov hash" -ForegroundColor Yellow
         gpg --verify $sig $sha
+        if ($LASTEXITCODE -ne 0) {
+            throw "Codecov CLI signature verification failed."
+        }
     } else {
         if ($AllowSkipVerify) {
             Write-Warning "gpg not found. Unable to verify hash signature."

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -99,9 +99,9 @@ if (!$IncludeAspNetCore) {
     $aspnetRuntimeVersions = @()
 }
 
-Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
+Function Get-FileFromWeb([Uri]$Uri, $OutDir, [switch]$Force) {
     $OutFile = Join-Path $OutDir $Uri.Segments[-1]
-    if (!(Test-Path $OutFile)) {
+    if ($Force -or !(Test-Path $OutFile)) {
         Write-Verbose "Downloading $Uri..."
         if (!(Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir | Out-Null }
         try {
@@ -134,38 +134,49 @@ Function Get-InstallerExe(
 
     $majorMinor = "$($TypedVersion.Major).$($TypedVersion.Minor)"
     $ReleasesFile = Join-Path $DotNetInstallScriptRoot "$majorMinor\releases.json"
-    if (!(Test-Path $ReleasesFile)) {
-        Get-FileFromWeb -Uri "https://builds.dotnet.microsoft.com/dotnet/release-metadata/$majorMinor/releases.json" -OutDir (Split-Path $ReleasesFile) | Out-Null
+    $ReleasesFileWasCached = Test-Path $ReleasesFile
+    $ReleasesUri = "https://builds.dotnet.microsoft.com/dotnet/release-metadata/$majorMinor/releases.json"
+    if (!$ReleasesFileWasCached) {
+        Get-FileFromWeb -Uri $ReleasesUri -OutDir (Split-Path $ReleasesFile) | Out-Null
     }
 
-    $releases = Get-Content $ReleasesFile | ConvertFrom-Json
     $url = $null
-    foreach ($release in $releases.releases) {
-        $filesElement = $null
-        if ($release.$sku.version -eq $Version) {
-            $filesElement = $release.$sku.files
-        }
-        if (!$filesElement -and ($sku -eq 'sdk') -and $release.sdks) {
-            foreach ($sdk in $release.sdks) {
-                if ($sdk.version -eq $Version) {
-                    $filesElement = $sdk.files
-                    break
+    for ($attempt = 0; $attempt -lt 2; $attempt++) {
+        $releases = Get-Content $ReleasesFile | ConvertFrom-Json
+        foreach ($release in $releases.releases) {
+            $filesElement = $null
+            if ($release.$sku.version -eq $Version) {
+                $filesElement = $release.$sku.files
+            }
+            if (!$filesElement -and ($sku -eq 'sdk') -and $release.sdks) {
+                foreach ($sdk in $release.sdks) {
+                    if ($sdk.version -eq $Version) {
+                        $filesElement = $sdk.files
+                        break
+                    }
                 }
             }
-        }
 
-        if ($filesElement) {
-            foreach ($file in $filesElement) {
-                if ($file.rid -eq "win-$Architecture") {
-                    $url = $file.url
+            if ($filesElement) {
+                foreach ($file in $filesElement) {
+                    if ($file.rid -eq "win-$Architecture") {
+                        $url = $file.url
+                        Break
+                    }
+                }
+
+                if ($url) {
                     Break
                 }
             }
-
-            if ($url) {
-                Break
-            }
         }
+
+        if ($url -or !$ReleasesFileWasCached -or $attempt -gt 0) {
+            break
+        }
+
+        Write-Verbose "Release not found in cached metadata. Refreshing $ReleasesUri..."
+        Get-FileFromWeb -Uri $ReleasesUri -OutDir (Split-Path $ReleasesFile) -Force | Out-Null
     }
 
     if ($url) {

--- a/tools/artifacts/testResults.ps1
+++ b/tools/artifacts/testResults.ps1
@@ -4,21 +4,25 @@ Param(
 
 $result = @{}
 
+# Hang and crash dumps are copied into the TRX attachment directory when a TRX report is requested.
+# Prefer that copy to avoid uploading the same dump twice, but keep the original when no attachment
+# copy exists (e.g. GitHub Actions runs, which don't request a TRX report) so crashes stay diagnosable.
+function Select-TestResultFile($files) {
+    $attachedDumpNames = @($files | Where-Object { $_.Extension -eq '.dmp' -and $_.FullName -match '[/\\]In[/\\]' } | ForEach-Object { $_.Name })
+    $files | Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' -or $attachedDumpNames -notcontains $_.Name }
+}
+
 $RepoRoot = Resolve-Path "$PSScriptRoot\..\.."
 $testRoot = Join-Path $RepoRoot test
 $legacyTestResults = Join-Path $testRoot TestResults
 if (Test-Path $legacyTestResults) {
-    $result[$testRoot] = Get-ChildItem $legacyTestResults -Recurse -Directory |
-        Get-ChildItem -Recurse -File |
-        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' }
+    $result[$testRoot] = Select-TestResultFile @(Get-ChildItem $legacyTestResults -Recurse -Directory | Get-ChildItem -Recurse -File)
 }
 
 $artifactStaging = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
 $testlogsPath = Join-Path $artifactStaging "test_logs"
 if (Test-Path $testlogsPath) {
-    # Hang and crash dumps are copied into the TRX attachment directory.
-    $result[$testlogsPath] = Get-ChildItem $testlogsPath -Recurse |
-        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' }
+    $result[$testlogsPath] = Select-TestResultFile @(Get-ChildItem $testlogsPath -Recurse)
 }
 
 $result

--- a/tools/artifacts/testResults.ps1
+++ b/tools/artifacts/testResults.ps1
@@ -10,7 +10,7 @@ $legacyTestResults = Join-Path $testRoot TestResults
 if (Test-Path $legacyTestResults) {
     $result[$testRoot] = Get-ChildItem $legacyTestResults -Recurse -Directory |
         Get-ChildItem -Recurse -File |
-        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '\\In\\' }
+        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' }
 }
 
 $artifactStaging = & "$PSScriptRoot/../Get-ArtifactsStagingDirectory.ps1"
@@ -18,7 +18,7 @@ $testlogsPath = Join-Path $artifactStaging "test_logs"
 if (Test-Path $testlogsPath) {
     # Hang and crash dumps are copied into the TRX attachment directory.
     $result[$testlogsPath] = Get-ChildItem $testlogsPath -Recurse |
-        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '\\In\\' }
+        Where-Object { $_.Extension -ne '.dmp' -or $_.FullName -match '[/\\]In[/\\]' }
 }
 
 $result

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -13,6 +13,8 @@
     A switch to run the tests in an x86 process.
 .PARAMETER dotnet32
     The path to a 32-bit dotnet executable to use.
+.PARAMETER NoCoverage
+    A switch to skip code coverage collection.
 #>
 [CmdletBinding()]
 Param(
@@ -20,7 +22,8 @@ Param(
     [string]$Agent='Local',
     [switch]$PublishResults,
     [switch]$x86,
-    [string]$dotnet32
+    [string]$dotnet32,
+    [switch]$NoCoverage
 )
 
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
@@ -60,10 +63,12 @@ if ($isMTP) {
         ,'--hangdump'
         ,'--hangdump-timeout','120s'
         ,'--crashdump'
+        ,'--crashdump-type','Heap'
+        # The native crash report accompanies the dump and is often the only way to identify the
+        # faulting thread and instruction when a test host dies of an access violation on Linux.
+        ,'--crash-report-if-supported'
     )
     $mtpArgs = @(
-        ,'--coverage'
-        ,'--coverage-output-format','cobertura'
         ,'--diagnostic'
         ,'--diagnostic-output-directory',$testLogs
         ,'--diagnostic-verbosity','Information'
@@ -71,12 +76,19 @@ if ($isMTP) {
         ,'--report-trx'
     )
 
+    if (-not $NoCoverage) {
+        $mtpArgs += @(
+            ,'--coverage'
+            ,'--coverage-output-format','cobertura'
+            ,'--coverage-settings',"$PSScriptRoot/test.runsettings"
+        )
+    }
+
     & $dotnet test --solution $RepoRoot `
         --no-build `
         -c $Configuration `
         -bl:"$testBinLog" `
         --filter-not-trait 'TestCategory=FailsInCloudTest' `
-        --coverage-settings "$PSScriptRoot/test.runsettings" `
         @mtpArgs `
         @dumpSwitches `
         @extraArgs
@@ -85,17 +97,24 @@ if ($isMTP) {
     $trxFiles = Get-ChildItem -Recurse -Path $testLogs\*.trx
 } else {
     $testDiagLog = Join-Path $ArtifactStagingFolder (Join-Path test_logs diag.log)
+    $coverageArgs = @()
+    if (-not $NoCoverage) {
+        $coverageArgs = @(
+            ,'--collect','Code Coverage;Format=cobertura'
+            ,'--settings',"$PSScriptRoot/test.runsettings"
+        )
+    }
+
     & $dotnet test $RepoRoot `
         --no-build `
         -c $Configuration `
         --filter "TestCategory!=FailsInCloudTest" `
-        --collect "Code Coverage;Format=cobertura" `
-        --settings "$PSScriptRoot/test.runsettings" `
         --blame-hang-timeout 60s `
         --blame-crash `
         -bl:"$testBinLog" `
         --diag "$testDiagLog;TraceLevel=info" `
         --logger trx `
+        @coverageArgs `
         @extraArgs
     if ($LASTEXITCODE -ne 0) { $failedTests += 1 }
 

--- a/tools/publish-CodeCov.ps1
+++ b/tools/publish-CodeCov.ps1
@@ -21,10 +21,31 @@ Param (
 )
 
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
+$codeCovTool = & "$PSScriptRoot/Get-CodeCovTool.ps1"
 
 Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml" | % {
     $relativeFilePath = Resolve-Path -relative $_.FullName
 
     Write-Host "Uploading: $relativeFilePath" -ForegroundColor Yellow
-    & (& "$PSScriptRoot/Get-CodeCovTool.ps1") -t $CodeCovToken -f $relativeFilePath -R $RepoRoot -F $Flags -n $Name
+    $arguments = @(
+        "upload-process",
+        "--disable-search",
+        "--fail-on-error",
+        "-t", $CodeCovToken,
+        "-f", $relativeFilePath,
+        "--network-root-folder", $RepoRoot
+    )
+    if ($Flags) {
+        $arguments += @("-F", $Flags)
+    }
+
+    if ($Name) {
+        $arguments += @("-n", $Name)
+    }
+
+    & $codeCovTool $arguments
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
+        exit $LASTEXITCODE
+    }
 }


### PR DESCRIPTION
This PR brings the repo up to date with the latest Library.Template changes so the build, test, and package-management setup stays aligned with the shared template.

### What changed
- Merged the template's updates to the SDK install/build scripts and cloud test workflow.
- Updated central package management and related configuration files while preserving the repo's existing package versions.
- Kept the repo-specific build/test behavior intact while adopting the template's newer structure.

### Validation
- dotnet restore
- dotnet build -c Release
- dotnet build -c Debug
- tools/dotnet-test-cloud.ps1 -Configuration Debug