### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.9.0",
+      "version": "18.10.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.6.4",
+      "version": "7.6.5",
       "commands": [
         "pwsh"
       ],

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -31,7 +31,7 @@
       "rollForward": false
     },
     "nerdbank.dotnetrepotools": {
-      "version": "1.5.15",
+      "version": "1.5.42",
       "commands": [
         "repo"
       ],

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
-    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Put repo-specific GlobalPackageReference items in this group. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <!-- Put repo-specific PackageVersion items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Telemetry" Version="$(MicrosoftTestingPlatformVersion)" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="System.IO.Pipes" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
-    <PackageVersion Include="xunit.v3.extensibility.core" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.extensibility.core" Version="4.0.0" />
     <PackageVersion Include="xunit.combinatorial" Version="2.0.24" />
   </ItemGroup>
   <ItemGroup Label="Library.Template">

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -43,7 +43,7 @@ if ($x86) {
       Write-Host "Running tests using `"$dotnet`"" -ForegroundColor DarkGray
     } else {
       Write-Error "Unable to find 32-bit dotnet.exe"
-      return 1
+      exit 1
     }
   }
 }

--- a/tools/dotnet-test-cloud.ps1
+++ b/tools/dotnet-test-cloud.ps1
@@ -61,7 +61,7 @@ if ($isMTP) {
 
     $dumpSwitches = @(
         ,'--hangdump'
-        ,'--hangdump-timeout','120s'
+        ,'--hangdump-timeout','5m'
         ,'--crashdump'
         ,'--crashdump-type','Heap'
         # The native crash report accompanies the dump and is often the only way to identify the
@@ -84,10 +84,17 @@ if ($isMTP) {
         )
     }
 
-    & $dotnet test --solution $RepoRoot `
+    $solutionFiles = @(Get-ChildItem -LiteralPath $RepoRoot -File | Where-Object { $_.Extension -in '.sln', '.slnx' })
+    if ($solutionFiles.Count -ne 1) {
+        throw "Expected exactly one solution file in $RepoRoot, but found $($solutionFiles.Count)."
+    }
+
+    $solutionPath = $solutionFiles[0].FullName
+    & $dotnet test $solutionPath `
         --no-build `
         -c $Configuration `
         -bl:"$testBinLog" `
+        -- `
         --filter-not-trait 'TestCategory=FailsInCloudTest' `
         @mtpArgs `
         @dumpSwitches `

--- a/tools/publish-CodeCov.ps1
+++ b/tools/publish-CodeCov.ps1
@@ -22,30 +22,34 @@ Param (
 
 $RepoRoot = (Resolve-Path "$PSScriptRoot/..").Path
 $codeCovTool = & "$PSScriptRoot/Get-CodeCovTool.ps1"
+$coverageFiles = @(Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml")
+if ($coverageFiles.Count -eq 0) {
+    return
+}
 
-Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml" | % {
-    $relativeFilePath = Resolve-Path -relative $_.FullName
-
+$arguments = @(
+    "upload-process",
+    "--disable-search",
+    "--fail-on-error",
+    "-t", $CodeCovToken,
+    "--network-root-folder", $RepoRoot
+)
+foreach ($coverageFile in $coverageFiles) {
+    $relativeFilePath = Resolve-Path -Relative $coverageFile.FullName
     Write-Host "Uploading: $relativeFilePath" -ForegroundColor Yellow
-    $arguments = @(
-        "upload-process",
-        "--disable-search",
-        "--fail-on-error",
-        "-t", $CodeCovToken,
-        "-f", $relativeFilePath,
-        "--network-root-folder", $RepoRoot
-    )
-    if ($Flags) {
-        $arguments += @("-F", $Flags)
-    }
+    $arguments += @("-f", $relativeFilePath)
+}
 
-    if ($Name) {
-        $arguments += @("-n", $Name)
-    }
+if ($Flags) {
+    $arguments += @("-F", $Flags)
+}
 
-    & $codeCovTool @arguments
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
-        exit $LASTEXITCODE
-    }
+if ($Name) {
+    $arguments += @("-n", $Name)
+}
+
+& $codeCovTool @arguments
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
+    exit $LASTEXITCODE
 }

--- a/tools/publish-CodeCov.ps1
+++ b/tools/publish-CodeCov.ps1
@@ -43,7 +43,7 @@ Get-ChildItem -Recurse -LiteralPath $PathToCodeCoverage -Filter "*.cobertura.xml
         $arguments += @("-n", $Name)
     }
 
-    & $codeCovTool $arguments
+    & $codeCovTool @arguments
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Codecov CLI failed with exit code $LASTEXITCODE."
         exit $LASTEXITCODE


### PR DESCRIPTION
- **Use ps1 splatting and exit instead of return**
- **Improve test and code coverage scripts**
- **Update dependency dotnet-coverage to v18.10.0 (552)**
- **Update dependency Microsoft.Testing.Extensions.CodeCoverage to 18.10.0 (553)**
- **Update dependency powershell to v7.6.5 (554)**
- **Update dependency xunit.v3.mtp-v2 to v4 (555)**
- **Update dependency nerdbank.dotnetrepotools to v1.5.42 (556)**
