### PR TITLE
Merge latest Library.Template updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1fc6e423f543119c406d24e2e687d67c569f18f04a37a8b0005d80ad0dcee80
+FROM mcr.microsoft.com/dotnet/sdk:10.0.400@sha256:e1ffd2a92ae84c1291bc1b6887501f8af98e6331e7af6d4c8d37168c5e87a64c
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
         if ('${{ inputs.ship_run_id }}') {
           $runid = '${{ inputs.ship_run_id }}'
         } else {
@@ -40,8 +43,8 @@ jobs:
 
           Write-Host "Resolved ${{ github.ref_name }} to $commitSha"
 
-          $releases = gh run list -R ${{ github.repository }} -c $commitSha -w .github/workflows/build.yml -s success --json databaseId,startedAt,event,headBranch `
-            | ConvertFrom-Json | Sort-Object startedAt -Descending
+          $releases = @(gh run list -R ${{ github.repository }} -c $commitSha -w .github/workflows/build.yml -s success --json databaseId,startedAt,event,headBranch `
+            | ConvertFrom-Json | Sort-Object startedAt -Descending)
 
           $preferredReleases = $releases | Where-Object {
             $_.event -eq 'push' -and ($_.headBranch -eq 'main' -or $_.headBranch -match '^v\d+(?:\.\d+)?$')
@@ -93,6 +96,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        $ErrorActionPreference = 'Stop'
+        $PSNativeCommandUseErrorActionPreference = $true
+
         Get-ChildItem '${{ runner.temp }}/deployables' -File -Recurse |% {
           Write-Host "Uploading $($_.Name) to release..."
           gh release -R ${{ github.repository }} upload "${{ github.ref_name }}" $_.FullName

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,10 @@ Having previously used `nbgv tag` and pushing the tag will help you identify the
 After publishing the release, the `.github/workflows/release.yml` workflow will be automatically triggered, which will:
 
 1. Find the most recent `.github/workflows/build.yml` GitHub workflow run of the tagged release.
-1. Upload the `deployables` artifact from that workflow run to your GitHub Release.
-1. If you have `NUGET_API_KEY` defined as a secret variable for your repo or org, any nuget packages in the `deployables` artifact will be pushed to nuget.org.
+1. Upload the `deployables-Linux` artifact from that workflow run to your GitHub Release.
+1. Any nuget packages in the `deployables-Linux` artifact will be pushed to nuget.org.
+
+The workflow is written to leverage NuGet.org Trusted Publishing.
 
 ### Azure Pipelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ After publishing the release, the `.github/workflows/release.yml` workflow will 
 1. Any nuget packages in the `deployables-Linux` artifact will be pushed to nuget.org.
 
 The workflow is written to leverage NuGet.org Trusted Publishing.
+You should set `NUGET_USER` as a repo secret to satisfy Trusted Publishing requirements.
 
 ### Azure Pipelines
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <!-- Put repo-specific GlobalPackageReference items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.12" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.19" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <!-- Put repo-specific GlobalPackageReference items in this group. -->
   </ItemGroup>
   <ItemGroup Label="Library.Template">
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.2.12" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <!-- The condition works around https://github.com/dotnet/sdk/issues/44951 -->
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.10.91" Condition="!('$(TF_BUILD)'=='true' and '$(dotnetformat)'=='true')" />


### PR DESCRIPTION
Refresh this repository with the latest Library.Template maintenance improvements and release automation guidance.

This merge:
- hardens the release workflow's PowerShell error handling and release-run selection
- documents NuGet.org Trusted Publishing requirements
- updates CSharpIsNullAnalyzer to 0.2.19
- refreshes the .NET SDK devcontainer image digest

The template merge completed without conflicts.

Validation:
- `dotnet restore`
- `dotnet build`
- `tools/dotnet-test-cloud.ps1` (2,067 tests, 0 failures)